### PR TITLE
chore(metro): alias legacy DatePickerIOS to shim to unblock bundling

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,0 +1,19 @@
+// metro.config.js
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { getDefaultConfig } = require('expo/metro-config');
+
+const config = getDefaultConfig(__dirname);
+
+config.resolver.resolveRequest = (context, realModuleName, platform) => {
+  if (
+    realModuleName === 'react-native/Libraries/Components/DatePicker/DatePickerIOS'
+  ) {
+    return {
+      type: 'sourceFile',
+      filePath: require('path').resolve(__dirname, 'shims/DatePickerIOS.js'),
+    };
+  }
+  return context.resolveRequest(context, realModuleName, platform);
+};
+
+module.exports = config;

--- a/shims/DatePickerIOS.js
+++ b/shims/DatePickerIOS.js
@@ -1,0 +1,3 @@
+// Legacy shim for removed DatePickerIOS. RN removed this module; this stub prevents Metro resolve errors.
+// No runtime usage expected; if a lib actually calls it, we'll see a follow-up error.
+module.exports = {};


### PR DESCRIPTION
React Native 0.70.8 still exports DatePickerIOS in index.js but the actual module files were removed, causing Metro bundler to fail with: "Unable to resolve module ./Libraries/Components/DatePicker/DatePickerIOS"

This adds:
- shims/DatePickerIOS.js: Empty stub module to satisfy the import
- metro.config.js: Custom resolver to alias the legacy path to our shim

The shim is inert unless a library actually calls DatePickerIOS at runtime. This will be removed once all dependencies stop referencing the legacy module.