### PR TITLE
fix: eliminate Context-state mutation and redundant storage reads in persistence hooks

### DIFF
--- a/__tests__/hooks/useHistory.test.tsx
+++ b/__tests__/hooks/useHistory.test.tsx
@@ -121,13 +121,11 @@ describe('useHistory', () => {
         await new Promise(resolve => setTimeout(resolve, 100));
       });
 
-      // StrictMode intentionally double-invokes effects, so the storage read
-      // may fire twice. The hook guards against double *application* via its
-      // hydrateCounter (only the latest run dispatches), rather than by
-      // suppressing the read itself. Assert the read targeted the right key
-      // and never ran more than StrictMode's double-invoke.
-      expect(mockStorage.getItem.mock.calls.length).toBeGreaterThanOrEqual(1);
-      expect(mockStorage.getItem.mock.calls.length).toBeLessThanOrEqual(2);
+      // StrictMode double-invokes effects on mount. The hydrate effect must
+      // guard the storage READ (not just the dispatch) so it fires exactly
+      // once even under the double-invoke — otherwise every StrictMode mount
+      // costs a redundant AsyncStorage read.
+      expect(mockStorage.getItem).toHaveBeenCalledTimes(1);
       expect(mockStorage.getItem).toHaveBeenCalledWith('storage:history:v1');
     });
 

--- a/hooks/__tests__/usePersistFilters.test.ts
+++ b/hooks/__tests__/usePersistFilters.test.ts
@@ -230,6 +230,36 @@ describe('usePersistFilters', () => {
     expect(mockAsyncStorage.setItem).toHaveBeenCalledTimes(1);
   });
 
+  test('does not mutate the caller\'s filter arrays while detecting changes', async () => {
+    mockAsyncStorage.getItem.mockResolvedValue(null);
+
+    const { rerender } = renderHook(
+      ({ filters }) => usePersistFilters(filters),
+      { initialProps: { filters: initialFilters } }
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Deliberately unsorted arrays. Change-detection must compare copies, not
+    // sort these in place — they come straight from Context state and mutating
+    // state is a React correctness bug.
+    const unsorted: Filters = {
+      ...initialFilters,
+      categoryIds: ['restaurants', 'bars'],
+      priceLevels: [2, 1],
+    };
+
+    rerender({ filters: unsorted });
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+
+    expect(unsorted.categoryIds).toEqual(['restaurants', 'bars']);
+    expect(unsorted.priceLevels).toEqual([2, 1]);
+  });
+
   test('should provide force save functionality', async () => {
     mockAsyncStorage.getItem.mockResolvedValue(null);
 

--- a/hooks/useHistory.ts
+++ b/hooks/useHistory.ts
@@ -40,13 +40,15 @@ export function useHistory() {
   const prevSerializedRef = useRef<string>('');
   const hydrateCounterRef = useRef(0);
 
-  // (a) One-time hydrate guard
+  // (a) One-time hydrate guard. `isHydratingRef` is set synchronously below,
+  // before the first await, so StrictMode's double-invoke short-circuits here
+  // on the second run instead of firing a redundant storage read.
   useEffect(() => {
-    if (hasHydratedRef.current) {
+    if (hasHydratedRef.current || isHydratingRef.current) {
       logSafe('[useHistory] Skipping duplicate hydration');
       return;
     }
-    
+
     isHydratingRef.current = true;
     hydrateCounterRef.current += 1;
     const runId = hydrateCounterRef.current;

--- a/hooks/usePersistFilters.ts
+++ b/hooks/usePersistFilters.ts
@@ -35,9 +35,12 @@ export interface UsePersistFiltersReturn {
  * Deep equality check for filters
  */
 function filtersEqual(a: Filters, b: Filters): boolean {
+  // Sort copies, never the inputs: `a` is the live Context state and `b` is the
+  // last-saved snapshot. Sorting them in place would mutate React state (a
+  // correctness bug) and reorder the user's category/price arrays.
   return (
-    safeStringify(a.categoryIds.sort()) === safeStringify(b.categoryIds.sort()) &&
-    safeStringify(a.priceLevels.sort()) === safeStringify(b.priceLevels.sort()) &&
+    safeStringify([...a.categoryIds].sort()) === safeStringify([...b.categoryIds].sort()) &&
+    safeStringify([...a.priceLevels].sort()) === safeStringify([...b.priceLevels].sort()) &&
     a.openNow === b.openNow &&
     a.radiusMeters === b.radiusMeters &&
     a.minRating === b.minRating


### PR DESCRIPTION
## Summary

Fixes two storage-I/O bugs in persistence hooks, surfaced while repairing the test suite (#13). Both are small, targeted fixes with regression tests added first (TDD).

## Bug 1 — `usePersistFilters` mutated Context state

`filtersEqual` sorted `categoryIds` / `priceLevels` **in place**:

```diff
- safeStringify(a.categoryIds.sort()) === safeStringify(b.categoryIds.sort())
+ safeStringify([...a.categoryIds].sort()) === safeStringify([...b.categoryIds].sort())
```

`a` is the live Context state and `b` is the last-saved snapshot, so the comparison mutated React state (a correctness bug) and reordered the user's arrays. Sorting copies fixes the mutation and restores order-independent dedup, so reordered-but-identical filters no longer trigger a redundant `AsyncStorage` write.

**Test added:** asserts the caller's arrays are not reordered during change detection.

## Bug 2 — `useHistory` double-read storage under StrictMode

The hydrate effect's guard only checked `hasHydratedRef`, which is set *after* the async `getItem` resolves. StrictMode double-invokes the mount effect, so both runs issued a storage read before either resolved (the `hydrateCounter` guard deduped the dispatch, not the read). Now the guard also short-circuits on `isHydratingRef`, set synchronously before the await → exactly one read.

**Test updated:** StrictMode hydration now asserts exactly one `getItem` call (was "at most two").

## Verification

- `yarn test` (full suite): **40 suites, 368 tests, 5 snapshots — all passing**, exit 0.
- No production behavior change beyond eliminating the state mutation and redundant reads.
