### PR TITLE
ci: run tests on PRs via GitHub Actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to `.env` and fill in real values for local development:
+#   cp .env.example .env
+#
+# react-native-dotenv inlines these at build/transform time (allowUndefined:false
+# in babel.config.js), so every key referenced via `@env` must be defined or the
+# build/tests fail. CI copies this file to `.env` to resolve @env with safe stubs.
+
+YELP_API_KEY=test-yelp-key
+GOOGLE_API_KEY=test-google-key
+
+# Set to 'true' to use mock Yelp data in development (avoids 429 rate limits)
+DEV_USE_MOCK=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
+      # react-native-dotenv (allowUndefined:false) resolves @env imports at
+      # transform time, so a .env must exist. The real .env is gitignored; use
+      # the checked-in example with safe stub values for CI.
+      - name: Provide test env
+        run: cp .env.example .env
+
       # The `test` script is `jest --watchAll`; override to a single CI run so
       # the job doesn't hang in watch mode.
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same ref (e.g. rapid pushes to a PR).
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      # The `test` script is `jest --watchAll`; override to a single CI run so
+      # the job doesn't hang in watch mode.
+      - name: Run tests
+        run: yarn test --watchAll=false --ci


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yml` — runs the Jest suite on every `pull_request` and `push` to `main`.

- Node from `.nvmrc` (24 LTS), `yarn install --frozen-lockfile`, yarn cache.
- Overrides the `test` script (`jest --watchAll`) with `--watchAll=false --ci` so it terminates instead of hanging in watch mode.
- `concurrency` cancels superseded runs on the same ref.

## Follow-up

Once this merges and the `Test` check has run, I'll add it as a **required status check** in `main`'s branch protection so no PR can merge with failing tests. This also gives the `github-actions` Dependabot entry something to keep updated.