### PR TITLE
chore(dependabot): ignore SDK-locked expo-* packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,12 +16,13 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Expo pins react-native/expo to SDK-compatible versions. Bumping them
-    # outside `expo install --fix` / an SDK upgrade breaks the app, so leave
-    # them to the Expo tooling rather than Dependabot.
+    # Expo pins expo, react-native, and the whole expo-* family to
+    # SDK-compatible versions. Bumping them outside `expo install --fix` /
+    # an SDK upgrade breaks the app, so leave them to the Expo tooling.
     ignore:
       - dependency-name: "expo"
       - dependency-name: "react-native"
+      - dependency-name: "expo-*"
 
   # GitHub Actions (covers workflows once they're added)
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Extends the Dependabot ignore list to the whole `expo-*` family. It joins `expo` and `react-native`, which were already ignored for the same reason: these are pinned to the Expo SDK (currently 54) and must move via `expo install --fix` or a coordinated SDK upgrade, never as independent bumps.

## Why

Dependabot opened 5 PRs (#19–#26) bumping `expo-web-browser`, `expo-asset`, `expo-linking`, `expo-font`, and `expo-haptics` to 57.x — far beyond SDK 54's pinned versions. Merging any would break the app. Those PRs are now closed; this config change stops them from reopening.

Minor/patch of non-Expo deps and legit majors (reviewed manually) are unaffected.