### PR TITLE
chore(dependabot): ignore SDK-locked React + native-module packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,13 +16,25 @@ updates:
         update-types:
           - "minor"
           - "patch"
-    # Expo pins expo, react-native, and the whole expo-* family to
-    # SDK-compatible versions. Bumping them outside `expo install --fix` /
-    # an SDK upgrade breaks the app, so leave them to the Expo tooling.
+    # Expo pins a whole constellation to SDK-compatible versions: expo itself,
+    # react-native, the expo-* family, the React runtime (which must match the
+    # version RN bundles), and the Expo-managed native modules. Bumping any of
+    # them outside `expo install --fix` / an SDK upgrade breaks the native and
+    # test stack, so leave them to the Expo tooling.
     ignore:
       - dependency-name: "expo"
       - dependency-name: "react-native"
       - dependency-name: "expo-*"
+      # React runtime — pinned to the version react-native bundles.
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "react-test-renderer"
+      - dependency-name: "@types/react"
+      # Expo-managed native modules — pinned by the SDK.
+      - dependency-name: "react-native-reanimated"
+      - dependency-name: "react-native-worklets"
+      - dependency-name: "react-native-screens"
+      - dependency-name: "react-native-safe-area-context"
 
   # GitHub Actions (covers workflows once they're added)
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

Extends the Dependabot ignore list to the React runtime and Expo-managed native modules, which are pinned by Expo SDK 54 / RN 0.81:

- `react`, `react-dom`, `react-test-renderer`, `@types/react` — must match the React version RN bundles (19.1.0)
- `react-native-reanimated`, `react-native-worklets`, `react-native-screens`, `react-native-safe-area-context` — SDK-managed native modules

## Why

The grouped minor/patch PR (#17) failed CI with `TurboModuleRegistry.get is not a function` and a worklets stack overflow — it bumped these SDK-locked packages past what the SDK pins. #17 is now closed; this stops the same bumps from recurring. The safe community deps in that group (`@react-navigation/*`, `react-native-dotenv`, `react-native-toast-message`) are still updatable and will come back as a clean, passing group.

Upgrade path for the locked set remains `expo install --fix` / a coordinated SDK bump.