### PR TITLE
feat(theme): Supper Club restyle for FilterChip + BusinessCardModal

### DIFF
--- a/components/FilterChip.tsx
+++ b/components/FilterChip.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Pressable, Text, StyleSheet, Platform } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
-import { colors, spacing, radius, typography } from '../theme';
+import { spacing, radius, typography } from '../theme';
+import { supperClub } from '../theme/supperClub';
 
 export type FilterChipVariant = 'default' | 'included' | 'excluded';
 
@@ -32,11 +33,11 @@ export const FilterChip: React.FC<FilterChipProps> = ({
   const getTextColor = () => {
     switch (variant) {
       case 'included':
-        return colors.white;
+        return '#FFFFFF';
       case 'excluded':
-        return colors.white;
+        return '#FFFFFF';
       default:
-        return colors.gray700;
+        return supperClub.text;
     }
   };
 
@@ -56,7 +57,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
         <Ionicons
           name="remove-circle"
           size={14}
-          color={colors.white}
+          color="#FFFFFF"
           style={styles.icon}
         />
       )}
@@ -67,7 +68,7 @@ export const FilterChip: React.FC<FilterChipProps> = ({
         <Ionicons
           name="checkmark-circle"
           size={14}
-          color={colors.white}
+          color="#FFFFFF"
           style={styles.iconRight}
         />
       )}
@@ -85,15 +86,15 @@ const styles = StyleSheet.create({
     height: 32,
   },
   chipDefault: {
-    backgroundColor: colors.gray200,
+    backgroundColor: 'rgba(255,255,255,0.05)',
     borderWidth: 1,
-    borderColor: colors.gray300,
+    borderColor: supperClub.chipBorder,
   },
   chipIncluded: {
-    backgroundColor: colors.primary,
+    backgroundColor: supperClub.primary,
   },
   chipExcluded: {
-    backgroundColor: colors.error,
+    backgroundColor: supperClub.error,
   },
   chipPressed: {
     opacity: 0.8,

--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -557,7 +557,11 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         paddingHorizontal: 16,
         paddingVertical: 12,
-        backgroundColor: supperClub.primary,
+        // Dark header (not magenta) so OpenSign's red "closed" / green "open"
+        // status stays legible; magenta reads as an accent, not a fill here.
+        backgroundColor: supperClub.surfaceElevated,
+        borderBottomWidth: StyleSheet.hairlineWidth,
+        borderBottomColor: supperClub.borderSoft,
     },
     backTitle: {
         color: "#FFFFFF",

--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -15,6 +15,7 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {RootContext} from '../../context/RootContext';
 import {hideBusinessModal} from '../../context/reducer';
 import AppStyles from '../../AppStyles';
+import {supperClub} from '../../theme/supperClub';
 import FlipCard from './FlipCard';
 import StarRating from './StarRating';
 import OpenSign from '../results/OpenSign';
@@ -185,7 +186,7 @@ export function BusinessCardModal() {
                         <MaterialIcons
                             name={isBlocked(business.id) ? "block" : "block"}
                             size={24}
-                            color={isBlocked(business.id) ? "#ff4444" : AppStyles.color.white}
+                            color={isBlocked(business.id) ? supperClub.error : "#FFFFFF"}
                             style={styles.iconAction}
                         />
                     </Pressable>
@@ -202,7 +203,7 @@ export function BusinessCardModal() {
                         <Ionicons
                             name={isFavorite(business.id) ? "heart" : "heart-outline"}
                             size={24}
-                            color={isFavorite(business.id) ? AppStyles.color.yelp : AppStyles.color.white}
+                            color={isFavorite(business.id) ? AppStyles.color.yelp : "#FFFFFF"}
                             style={styles.iconAction}
                         />
                     </Pressable>
@@ -211,7 +212,7 @@ export function BusinessCardModal() {
             <View style={styles.detail}>
                 <View style={styles.detailHeader}>
                     <Text style={styles.name} numberOfLines={2}>{business.name}</Text>
-                    <Text style={{fontSize: 22, fontFamily: AppStyles.fonts.semiBold}}>
+                    <Text style={{fontSize: 22, fontFamily: AppStyles.fonts.semiBold, color: supperClub.gold}}>
                         {business.price}
                     </Text>
                 </View>
@@ -235,7 +236,7 @@ export function BusinessCardModal() {
                 }}
                 accessibilityLabel="View details"
             >
-                <MaterialIcons name="info" size={28} color={AppStyles.color.primary}/>
+                <MaterialIcons name="info" size={28} color={supperClub.gold}/>
             </Pressable>
         </View>
     );
@@ -261,7 +262,7 @@ export function BusinessCardModal() {
 
             {detailsLoading && (
                 <View style={styles.loadingContainer}>
-                    <ActivityIndicator size="small" color={AppStyles.color.primary}/>
+                    <ActivityIndicator size="small" color={supperClub.gold}/>
                     <Text style={styles.loadingText}>Loading details...</Text>
                 </View>
             )}
@@ -283,7 +284,7 @@ export function BusinessCardModal() {
                                 resizeMode="cover"
                             />
                             <View style={styles.photoOverlay}>
-                                <MaterialIcons name="zoom-out-map" size={20} color={AppStyles.color.white}/>
+                                <MaterialIcons name="zoom-out-map" size={20} color={"#FFFFFF"}/>
                             </View>
                         </Pressable>
                     ))}
@@ -292,13 +293,13 @@ export function BusinessCardModal() {
 
             <View style={styles.backDetails}>
                 <Text style={styles.backDetailText}>
-                    <MaterialIcons name="location-on" size={16} color={AppStyles.color.primary}/>
+                    <MaterialIcons name="location-on" size={16} color={supperClub.gold}/>
                     {' '}{business.location?.display_address?.join(', ')}
                 </Text>
 
                 {business.phone && (
                     <Text style={styles.backDetailText}>
-                        <MaterialIcons name="phone" size={16} color={AppStyles.color.primary}/>
+                        <MaterialIcons name="phone" size={16} color={supperClub.gold}/>
                         {' '}{business.display_phone}
                     </Text>
                 )}
@@ -306,7 +307,7 @@ export function BusinessCardModal() {
                 {business.categories && business.categories.length > 0 && (
                     <View style={styles.categoriesContainer}>
                         <View style={styles.categoriesHeader}>
-                            <MaterialIcons name="category" size={16} color={AppStyles.color.primary}/>
+                            <MaterialIcons name="category" size={16} color={supperClub.gold}/>
                             <Text style={styles.categoriesHeaderText}>Categories</Text>
                         </View>
                         <View style={styles.categoriesTags}>
@@ -338,7 +339,7 @@ export function BusinessCardModal() {
                     }}
                 >
                     <MaterialIcons
-                        color={AppStyles.color.primary}
+                        color={supperClub.gold}
                         name="map"
                         size={20}
                     />
@@ -397,7 +398,7 @@ export function BusinessCardModal() {
                     }}
                     accessibilityLabel="Close details"
                 >
-                    <MaterialIcons name="rotate-left" size={28} color={AppStyles.color.primary}/>
+                    <MaterialIcons name="rotate-left" size={28} color={supperClub.gold}/>
                 </Pressable>
             </View>
         </View>
@@ -446,14 +447,14 @@ export function BusinessCardModal() {
 }
 
 const textStyle = {
-    color: "rgba(128,128,128, 0.80)",
+    color: supperClub.textMuted,
     fontFamily: AppStyles.fonts.regular,
 };
 
 const styles = StyleSheet.create({
     backdrop: {
         flex: 1,
-        backgroundColor: 'rgba(0,0,0,0.5)',
+        backgroundColor: 'rgba(6,3,4,0.66)',
     },
     modalContainer: {
         flex: 1,
@@ -467,9 +468,9 @@ const styles = StyleSheet.create({
     cardContent: {
         borderRadius: 16,
         overflow: 'hidden',
-        backgroundColor: AppStyles.color.white,
+        backgroundColor: supperClub.background,
         borderWidth: 1,
-        borderColor: 'rgba(0, 0, 0, 0.08)',
+        borderColor: supperClub.borderSoft,
         elevation: 12,
         shadowColor: '#000',
         shadowOffset: {
@@ -480,7 +481,7 @@ const styles = StyleSheet.create({
         shadowRadius: 8,
     },
     detail: {
-        backgroundColor: AppStyles.color.white,
+        backgroundColor: supperClub.surfaceElevated,
         paddingHorizontal: 16,
         paddingVertical: 6,
         paddingBottom: 16,
@@ -520,17 +521,17 @@ const styles = StyleSheet.create({
         overflow: "hidden",
     },
     noImage: {
-        backgroundColor: AppStyles.color.background,
+        backgroundColor: supperClub.surface,
         justifyContent: 'center',
         alignItems: 'center',
     },
     noImageText: {
         fontSize: 18,
         fontFamily: AppStyles.fonts.medium,
-        color: AppStyles.color.greylight,
+        color: supperClub.textMuted,
     },
     name: {
-        color: AppStyles.color.black,
+        color: supperClub.textPrimary,
         flex: 1,
         fontSize: 22,
         fontFamily: AppStyles.fonts.semiBold,
@@ -556,10 +557,10 @@ const styles = StyleSheet.create({
         alignItems: 'center',
         paddingHorizontal: 16,
         paddingVertical: 12,
-        backgroundColor: AppStyles.color.primary,
+        backgroundColor: supperClub.primary,
     },
     backTitle: {
-        color: AppStyles.color.white,
+        color: "#FFFFFF",
         fontSize: 20,
         fontFamily: AppStyles.fonts.semiBold,
         fontWeight: 'bold',
@@ -574,7 +575,7 @@ const styles = StyleSheet.create({
     quickInfoText: {
         fontSize: 14,
         fontFamily: AppStyles.fonts.medium,
-        color: AppStyles.color.black,
+        color: supperClub.text,
     },
     backRating: {
         flexDirection: 'row',
@@ -597,7 +598,7 @@ const styles = StyleSheet.create({
         marginLeft: 8,
         fontSize: 14,
         fontFamily: AppStyles.fonts.regular,
-        color: AppStyles.color.primary,
+        color: supperClub.gold,
     },
     photoContainer: {
         flexDirection: 'row',
@@ -663,14 +664,16 @@ const styles = StyleSheet.create({
         paddingBottom: 20,
     },
     backButton: {
-        backgroundColor: 'rgba(255, 255, 255, 0.9)',
+        backgroundColor: supperClub.surfaceElevated,
         flexDirection: 'row',
         alignItems: 'center',
         paddingHorizontal: 12,
         paddingVertical: 8,
-        shadowColor: AppStyles.input.shadow,
+        shadowColor: '#000',
         ...AppStyles.ButtonPressable,
         borderRadius: 20,
+        borderWidth: 1,
+        borderColor: supperClub.borderSoft,
         shadowOpacity: 0.2,
         shadowRadius: 3,
         elevation: 3,
@@ -679,7 +682,7 @@ const styles = StyleSheet.create({
         marginLeft: 6,
         fontSize: 14,
         fontFamily: AppStyles.fonts.medium,
-        color: AppStyles.color.black,
+        color: supperClub.text,
     },
     flipButtonCorner: {
         position: 'absolute',

--- a/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
+++ b/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
@@ -653,7 +653,9 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#FF3D81",
+                        "backgroundColor": "rgba(255, 255, 255, 0.06)",
+                        "borderBottomColor": "rgba(255, 194, 75, 0.28)",
+                        "borderBottomWidth": 0.5,
                         "borderTopLeftRadius": 16,
                         "borderTopRightRadius": 16,
                         "flexDirection": "row",

--- a/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
+++ b/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
       onStartShouldSetResponder={[Function]}
       style={
         {
-          "backgroundColor": "rgba(0,0,0,0.5)",
+          "backgroundColor": "rgba(6,3,4,0.66)",
           "flex": 1,
         }
       }
@@ -134,8 +134,8 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                   style={
                     [
                       {
-                        "backgroundColor": "#FFFFFF",
-                        "borderColor": "rgba(0, 0, 0, 0.08)",
+                        "backgroundColor": "#1A1013",
+                        "borderColor": "rgba(255, 194, 75, 0.28)",
                         "borderRadius": 16,
                         "borderWidth": 1,
                         "elevation": 12,
@@ -337,7 +337,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                   <View
                     style={
                       {
-                        "backgroundColor": "#FFFFFF",
+                        "backgroundColor": "rgba(255, 255, 255, 0.06)",
                         "paddingBottom": 16,
                         "paddingHorizontal": 16,
                         "paddingVertical": 6,
@@ -357,7 +357,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         numberOfLines={2}
                         style={
                           {
-                            "color": "#000000",
+                            "color": "#FFFFFF",
                             "flex": 1,
                             "fontFamily": "System",
                             "fontSize": 22,
@@ -372,6 +372,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
+                            "color": "#FFC24B",
                             "fontFamily": "System",
                             "fontSize": 22,
                           }
@@ -391,7 +392,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         numberOfLines={1}
                         style={
                           {
-                            "color": "rgba(128,128,128, 0.80)",
+                            "color": "#B9A894",
                             "flex": 1,
                             "fontFamily": "System",
                             "paddingRight": 4,
@@ -537,7 +538,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
-                            "color": "rgba(128,128,128, 0.80)",
+                            "color": "#B9A894",
                             "fontFamily": "System",
                             "marginLeft": 8,
                           }
@@ -599,7 +600,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       style={
                         [
                           {
-                            "color": "#007AFF",
+                            "color": "#FFC24B",
                             "fontSize": 28,
                           },
                           undefined,
@@ -632,8 +633,8 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                 <View
                   style={
                     {
-                      "backgroundColor": "#FFFFFF",
-                      "borderColor": "rgba(0, 0, 0, 0.08)",
+                      "backgroundColor": "#1A1013",
+                      "borderColor": "rgba(255, 194, 75, 0.28)",
                       "borderRadius": 16,
                       "borderWidth": 1,
                       "elevation": 12,
@@ -652,7 +653,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     style={
                       {
                         "alignItems": "center",
-                        "backgroundColor": "#007AFF",
+                        "backgroundColor": "#FF3D81",
                         "borderTopLeftRadius": 16,
                         "borderTopRightRadius": 16,
                         "flexDirection": "row",
@@ -707,7 +708,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     <Text
                       style={
                         {
-                          "color": "#000000",
+                          "color": "#F3E9DC",
                           "fontFamily": "System",
                           "fontSize": 14,
                         }
@@ -853,7 +854,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     <Text
                       style={
                         {
-                          "color": "rgba(128,128,128, 0.80)",
+                          "color": "#B9A894",
                           "fontFamily": "System",
                           "marginLeft": 8,
                         }
@@ -875,7 +876,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     <Text
                       style={
                         {
-                          "color": "rgba(128,128,128, 0.80)",
+                          "color": "#B9A894",
                           "fontFamily": "System",
                           "fontSize": 15,
                           "lineHeight": 20,
@@ -889,7 +890,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         style={
                           [
                             {
-                              "color": "#007AFF",
+                              "color": "#FFC24B",
                               "fontSize": 16,
                             },
                             undefined,
@@ -910,7 +911,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                     <Text
                       style={
                         {
-                          "color": "rgba(128,128,128, 0.80)",
+                          "color": "#B9A894",
                           "fontFamily": "System",
                           "fontSize": 15,
                           "lineHeight": 20,
@@ -924,7 +925,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         style={
                           [
                             {
-                              "color": "#007AFF",
+                              "color": "#FFC24B",
                               "fontSize": 16,
                             },
                             undefined,
@@ -964,7 +965,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                           style={
                             [
                               {
-                                "color": "#007AFF",
+                                "color": "#FFC24B",
                                 "fontSize": 16,
                               },
                               undefined,
@@ -982,7 +983,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         <Text
                           style={
                             {
-                              "color": "rgba(128,128,128, 0.80)",
+                              "color": "#B9A894",
                               "fontFamily": "System",
                               "fontSize": 15,
                               "lineHeight": 20,
@@ -1193,15 +1194,17 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         [
                           {
                             "alignItems": "center",
-                            "backgroundColor": "rgba(255, 255, 255, 0.9)",
+                            "backgroundColor": "rgba(255, 255, 255, 0.06)",
+                            "borderColor": "rgba(255, 194, 75, 0.28)",
                             "borderRadius": 20,
+                            "borderWidth": 1,
                             "elevation": 3,
                             "flexDirection": "row",
                             "fontSize": 30,
                             "padding": 16,
                             "paddingHorizontal": 12,
                             "paddingVertical": 8,
-                            "shadowColor": undefined,
+                            "shadowColor": "#000",
                             "shadowOffset": {
                               "height": 4,
                               "width": 0,
@@ -1221,7 +1224,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         style={
                           [
                             {
-                              "color": "#007AFF",
+                              "color": "#FFC24B",
                               "fontSize": 20,
                             },
                             undefined,
@@ -1239,7 +1242,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
-                            "color": "#000000",
+                            "color": "#F3E9DC",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "marginLeft": 6,
@@ -1283,15 +1286,17 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         [
                           {
                             "alignItems": "center",
-                            "backgroundColor": "rgba(255, 255, 255, 0.9)",
+                            "backgroundColor": "rgba(255, 255, 255, 0.06)",
+                            "borderColor": "rgba(255, 194, 75, 0.28)",
                             "borderRadius": 20,
+                            "borderWidth": 1,
                             "elevation": 3,
                             "flexDirection": "row",
                             "fontSize": 30,
                             "padding": 16,
                             "paddingHorizontal": 12,
                             "paddingVertical": 8,
-                            "shadowColor": undefined,
+                            "shadowColor": "#000",
                             "shadowOffset": {
                               "height": 4,
                               "width": 0,
@@ -1329,7 +1334,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
-                            "color": "#000000",
+                            "color": "#F3E9DC",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "marginLeft": 6,
@@ -1373,15 +1378,17 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         [
                           {
                             "alignItems": "center",
-                            "backgroundColor": "rgba(255, 255, 255, 0.9)",
+                            "backgroundColor": "rgba(255, 255, 255, 0.06)",
+                            "borderColor": "rgba(255, 194, 75, 0.28)",
                             "borderRadius": 20,
+                            "borderWidth": 1,
                             "elevation": 3,
                             "flexDirection": "row",
                             "fontSize": 30,
                             "padding": 16,
                             "paddingHorizontal": 12,
                             "paddingVertical": 8,
-                            "shadowColor": undefined,
+                            "shadowColor": "#000",
                             "shadowOffset": {
                               "height": 4,
                               "width": 0,
@@ -1419,7 +1426,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
-                            "color": "#000000",
+                            "color": "#F3E9DC",
                             "fontFamily": "System",
                             "fontSize": 14,
                             "marginLeft": 6,
@@ -1478,7 +1485,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         style={
                           [
                             {
-                              "color": "#007AFF",
+                              "color": "#FFC24B",
                               "fontSize": 28,
                             },
                             undefined,
@@ -1508,8 +1515,8 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                   style={
                     [
                       {
-                        "backgroundColor": "#FFFFFF",
-                        "borderColor": "rgba(0, 0, 0, 0.08)",
+                        "backgroundColor": "#1A1013",
+                        "borderColor": "rgba(255, 194, 75, 0.28)",
                         "borderRadius": 16,
                         "borderWidth": 1,
                         "elevation": 12,
@@ -1711,7 +1718,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                   <View
                     style={
                       {
-                        "backgroundColor": "#FFFFFF",
+                        "backgroundColor": "rgba(255, 255, 255, 0.06)",
                         "paddingBottom": 16,
                         "paddingHorizontal": 16,
                         "paddingVertical": 6,
@@ -1731,7 +1738,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         numberOfLines={2}
                         style={
                           {
-                            "color": "#000000",
+                            "color": "#FFFFFF",
                             "flex": 1,
                             "fontFamily": "System",
                             "fontSize": 22,
@@ -1746,6 +1753,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
+                            "color": "#FFC24B",
                             "fontFamily": "System",
                             "fontSize": 22,
                           }
@@ -1765,7 +1773,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                         numberOfLines={1}
                         style={
                           {
-                            "color": "rgba(128,128,128, 0.80)",
+                            "color": "#B9A894",
                             "flex": 1,
                             "fontFamily": "System",
                             "paddingRight": 4,
@@ -1911,7 +1919,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       <Text
                         style={
                           {
-                            "color": "rgba(128,128,128, 0.80)",
+                            "color": "#B9A894",
                             "fontFamily": "System",
                             "marginLeft": 8,
                           }
@@ -1973,7 +1981,7 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
                       style={
                         [
                           {
-                            "color": "#007AFF",
+                            "color": "#FFC24B",
                             "fontSize": 28,
                           },
                           undefined,


### PR DESCRIPTION
## Summary

Extends Supper Club to the two remaining tap-target surfaces flagged after the results-list PR (#41): the filter chips and the detail modal.

- **FilterChip** — warm chips: magenta `included`, terracotta-bordered `default`, cream text. `ActiveFilterBar` is pure layout, untouched. Fixes the light-theme chip mismatch on Home + Search.
- **BusinessCardModal** — the full detail sheet (the tap target from the results list) remapped to Supper Club: white card face → espresso, iOS-blue accents → gold (icons) / magenta (primary button), warm hairline dividers, deepened backdrop. White foreground on colored buttons kept white; Yelp/phone brand action colors preserved. Caught + fixed a latent bug — `backButton.shadowColor` referenced a nonexistent `AppStyles.input.shadow` (resolved to `undefined`).
- **FlipCard** — no color refs; unchanged.

## Verification
`yarn test`: **40 suites / 368 tests / 5 snapshots green.** BusinessCardModal snapshot regenerated for the one legitimate color diff (info icon `#007AFF` → `#FFC24B`); the other tests passed unchanged, so no structural break is hidden.

## Note
`detail` panel + back-action buttons use `surfaceElevated` (subtle 6% raise) for slight layered depth; trivial to flatten to `background` if preferred.