### PR TITLE
feat(theme): promote Supper Club across remaining screens

### DIFF
--- a/components/filter/FiltersSheet.tsx
+++ b/components/filter/FiltersSheet.tsx
@@ -14,6 +14,7 @@ import Config from '../../Config';
 import { RootContext } from '../../context/RootContext';
 import { setFilters, resetFilters } from '../../context/reducer';
 import AppStyles from '../../AppStyles';
+import { supperClub } from '../../theme/supperClub';
 import { Text } from '../Themed';
 import Divider from '../shared/Divider';
 import { Filters } from '../../context/state';
@@ -130,8 +131,8 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
       visible={visible}
       testID={testID}
     >
-      <StatusBar backgroundColor={AppStyles.color.white} />
-      <SafeAreaView style={{ flex: 1, backgroundColor: AppStyles.color.white }}>
+      <StatusBar backgroundColor={supperClub.background} />
+      <SafeAreaView style={{ flex: 1, backgroundColor: supperClub.background }}>
         {/* Header */}
         <View style={styles.header}>
           <View style={{ flex: 1, alignItems: 'flex-start' }}>
@@ -142,7 +143,7 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
               onPress={handleClose}
               android_ripple={{ color: 'grey', radius: 20, borderless: true }}
             >
-              <Icon name="close" size={25} color="black" />
+              <Icon name="close" size={25} color={supperClub.text} />
             </Pressable>
           </View>
           <Text style={styles.headerText}>Filters</Text>
@@ -248,7 +249,7 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
                     <Icon
                       name={showAllCategories ? 'keyboard-arrow-up' : 'keyboard-arrow-down'}
                       size={20}
-                      color={AppStyles.color.primary}
+                      color={supperClub.gold}
                     />
                   </Pressable>
                 )}
@@ -268,8 +269,8 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
               <Switch
                 value={localFilters.openNow}
                 onValueChange={(value) => updateLocalFilters({ openNow: value })}
-                trackColor={{ false: AppStyles.color.greylight, true: AppStyles.color.roulette.green }}
-                thumbColor={AppStyles.color.white}
+                trackColor={{ false: supperClub.textMuted, true: supperClub.success }}
+                thumbColor={'#FFFFFF'}
               />
             </View>
           </View>
@@ -299,10 +300,10 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
                           key={key} 
                           name="attach-money" 
                           size={18} 
-                          color={localFilters.priceLevels.includes(level as 1|2|3|4) 
-                            ? AppStyles.color.white 
-                            : AppStyles.color.roulette.accent
-                          } 
+                          color={localFilters.priceLevels.includes(level as 1|2|3|4)
+                            ? '#FFFFFF'
+                            : supperClub.gold
+                          }
                         />
                       ))}
                     </View>
@@ -381,10 +382,10 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
                           key={key} 
                           name="star" 
                           size={16} 
-                          color={localFilters.minRating === rating 
-                            ? AppStyles.color.white 
-                            : AppStyles.color.roulette.accent
-                          } 
+                          color={localFilters.minRating === rating
+                            ? '#FFFFFF'
+                            : supperClub.gold
+                          }
                         />
                       ))
                     )}
@@ -434,28 +435,29 @@ const styles = StyleSheet.create({
     fontSize: 22,
     textAlign: 'center',
     textAlignVertical: 'center',
+    color: '#FFFFFF',
   },
   resetText: {
     fontSize: 16,
-    color: AppStyles.color.roulette.red,
+    color: supperClub.textMuted,
     fontFamily: AppStyles.fonts.medium,
   },
   headerShadow: {
-    backgroundColor: AppStyles.color.greydark,
+    backgroundColor: supperClub.borderSoft,
     elevation: 4,
     height: Config.isAndroid ? 0.2 : 1,
   },
   fixedSelectedSection: {
-    backgroundColor: AppStyles.color.gray50,
+    backgroundColor: supperClub.surfaceElevated,
     paddingVertical: 12,
     paddingHorizontal: 16,
     borderBottomWidth: 1,
-    borderBottomColor: AppStyles.color.gray300,
+    borderBottomColor: supperClub.borderSoft,
   },
   fixedSelectedLabel: {
     fontSize: 12,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.gray500,
+    color: supperClub.textMuted,
     marginBottom: 8,
     textTransform: 'uppercase',
     letterSpacing: 0.5,
@@ -469,13 +471,13 @@ const styles = StyleSheet.create({
     paddingBottom: 8,
   },
   sectionTitle: {
-    color: AppStyles.color.black,
+    color: '#FFFFFF',
     fontFamily: AppStyles.fonts.bold,
     fontSize: 18,
     paddingVertical: 8,
   },
   sectionSubtitle: {
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
     fontFamily: AppStyles.fonts.regular,
     fontSize: 14,
   },
@@ -489,14 +491,15 @@ const styles = StyleSheet.create({
     marginHorizontal: 4,
   },
   priceButton: {
-    borderColor: AppStyles.color.roulette.accent,
+    borderColor: supperClub.borderSoft,
     borderRadius: 24,
     borderWidth: 1,
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     overflow: 'hidden',
   },
   priceButtonSelected: {
-    backgroundColor: AppStyles.color.roulette.accent,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   priceButtonText: {
     flexDirection: 'row',
@@ -513,29 +516,29 @@ const styles = StyleSheet.create({
   categoryChip: {
     flexDirection: 'row',
     alignItems: 'center',
-    borderColor: AppStyles.color.gray300,
+    borderColor: supperClub.borderSoft,
     borderWidth: 1,
     borderRadius: 16,
     paddingHorizontal: 12,
     paddingVertical: 6,
     margin: 4,
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
   },
   categoryChipIncluded: {
-    backgroundColor: AppStyles.color.success,
-    borderColor: AppStyles.color.success,
+    backgroundColor: supperClub.success,
+    borderColor: supperClub.success,
   },
   categoryChipExcluded: {
-    backgroundColor: AppStyles.color.accentRed,
-    borderColor: AppStyles.color.accentRed,
+    backgroundColor: supperClub.error,
+    borderColor: supperClub.error,
   },
   categoryChipText: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.gray500,
+    color: supperClub.text,
   },
   categoryChipTextSelected: {
-    color: AppStyles.color.white,
+    color: '#FFFFFF',
   },
   categoryIcon: {
     marginRight: 4,
@@ -551,7 +554,7 @@ const styles = StyleSheet.create({
   showMoreText: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.primary,
+    color: supperClub.gold,
     marginRight: 4,
   },
   switchContainer: {
@@ -565,7 +568,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.greydark,
+    color: supperClub.text,
     marginRight: 16,
   },
   distanceContainer: {
@@ -575,24 +578,25 @@ const styles = StyleSheet.create({
   },
   distanceOption: {
     flex: 1,
-    borderColor: AppStyles.color.roulette.neutral,
+    borderColor: supperClub.borderSoft,
     borderWidth: 1,
     borderRadius: 8,
     paddingVertical: 8,
     marginHorizontal: 2,
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
   },
   distanceOptionSelected: {
-    backgroundColor: AppStyles.color.roulette.neutral,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   distanceOptionText: {
     textAlign: 'center',
     fontSize: 14,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.roulette.neutral,
+    color: supperClub.text,
   },
   distanceOptionTextSelected: {
-    color: AppStyles.color.white,
+    color: '#FFFFFF',
   },
   ratingContainer: {
     flexDirection: 'row',
@@ -601,15 +605,16 @@ const styles = StyleSheet.create({
   },
   ratingOption: {
     flex: 1,
-    borderColor: AppStyles.color.roulette.accent,
+    borderColor: supperClub.borderSoft,
     borderWidth: 1,
     borderRadius: 8,
     paddingVertical: 8,
     marginHorizontal: 2,
-    backgroundColor: 'transparent',
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
   },
   ratingOptionSelected: {
-    backgroundColor: AppStyles.color.roulette.accent,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   ratingStars: {
     flexDirection: 'row',
@@ -620,15 +625,15 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     fontSize: 14,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.roulette.accent,
+    color: supperClub.gold,
   },
   ratingOptionTextSelected: {
-    color: AppStyles.color.white,
+    color: '#FFFFFF',
   },
   ratingPlusText: {
     fontSize: 12,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.roulette.accent,
+    color: supperClub.gold,
     marginLeft: 2,
   },
   buttonContainer: {
@@ -644,7 +649,7 @@ const styles = StyleSheet.create({
   },
   button: {
     alignItems: 'center',
-    backgroundColor: AppStyles.color.roulette.accent,
+    backgroundColor: supperClub.primary,
     height: 48,
     justifyContent: 'center',
   },

--- a/screens/BlockedScreen.tsx
+++ b/screens/BlockedScreen.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { View } from '../components/Themed';
 import FavoriteCard from '../components/shared/FavoriteCard';
 import AppStyles from '../AppStyles';
+import { supperClub } from '../theme/supperClub';
 import { useBlocked } from '../hooks/useBlocked';
 import { MaterialIcons, Ionicons } from '@expo/vector-icons';
 import { FavoriteItem } from '../types/favorites';
@@ -62,7 +63,7 @@ const BlockedScreen: React.FC = () => {
                 ]}
                 onPress={toggleSearch}
                 android_ripple={{
-                  color: AppStyles.color.background,
+                  color: supperClub.borderSoft,
                   radius: 20,
                   borderless: true,
                 }}
@@ -70,7 +71,7 @@ const BlockedScreen: React.FC = () => {
                 <MaterialIcons
                   name={showSearch ? "close" : "search"}
                   size={24}
-                  color={AppStyles.color.primary}
+                  color={supperClub.gold}
                 />
               </Pressable>
             )}
@@ -81,7 +82,7 @@ const BlockedScreen: React.FC = () => {
               <MaterialIcons
                 name="search"
                 size={20}
-                color={AppStyles.color.greylight}
+                color={supperClub.textMuted}
                 style={styles.searchIcon}
               />
               <TextInput
@@ -91,7 +92,7 @@ const BlockedScreen: React.FC = () => {
                 onChangeText={setSearchQuery}
                 autoFocus
                 returnKeyType="search"
-                placeholderTextColor={AppStyles.color.greylight}
+                placeholderTextColor={supperClub.textMuted}
               />
               {searchQuery.length > 0 && (
                 <Pressable
@@ -101,7 +102,7 @@ const BlockedScreen: React.FC = () => {
                   <MaterialIcons
                     name="clear"
                     size={20}
-                    color={AppStyles.color.greylight}
+                    color={supperClub.textMuted}
                   />
                 </Pressable>
               )}
@@ -120,7 +121,7 @@ const BlockedScreen: React.FC = () => {
           />
         ) : blocked.length === 0 ? (
           <View style={styles.emptyState}>
-            <MaterialIcons name="block" size={64} color={AppStyles.color.gray300} />
+            <MaterialIcons name="block" size={64} color={supperClub.textMuted} />
             <Text style={styles.emptyTitle}>No blocked restaurants</Text>
             <Text style={styles.emptyText}>
               Restaurants you block will appear here and won't show up in your search results.
@@ -128,7 +129,7 @@ const BlockedScreen: React.FC = () => {
           </View>
         ) : (
           <View style={styles.emptyState}>
-            <MaterialIcons name="search-off" size={64} color={AppStyles.color.gray300} />
+            <MaterialIcons name="search-off" size={64} color={supperClub.textMuted} />
             <Text style={styles.emptyTitle}>No matches found</Text>
             <Text style={styles.emptyText}>
               Try adjusting your search or browse all {blocked.length} blocked restaurants.
@@ -145,15 +146,15 @@ const BlockedScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: supperClub.background,
   },
   header: {
     paddingTop: 20,
     paddingBottom: 16,
     paddingHorizontal: 16,
-    backgroundColor: AppStyles.color.white,
+    backgroundColor: supperClub.surfaceElevated,
     borderBottomWidth: 1,
-    borderBottomColor: AppStyles.color.background,
+    borderBottomColor: supperClub.borderSoft,
   },
   titleRow: {
     flexDirection: 'row',
@@ -166,16 +167,16 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     marginBottom: 4,
   },
   subtitle: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
   },
   searchButton: {
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderRadius: 24,
     width: 48,
     height: 48,
@@ -193,7 +194,7 @@ const styles = StyleSheet.create({
   searchContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderRadius: 12,
     marginTop: 12,
     paddingHorizontal: 12,
@@ -206,7 +207,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.black,
+    color: supperClub.text,
     paddingVertical: 4,
   },
   clearButton: {
@@ -228,7 +229,7 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 24,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     textAlign: 'center',
     marginTop: 16,
     marginBottom: 12,
@@ -236,7 +237,7 @@ const styles = StyleSheet.create({
   emptyText: {
     fontSize: 16,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
     textAlign: 'center',
     lineHeight: 24,
   },

--- a/screens/FavoritesScreen.tsx
+++ b/screens/FavoritesScreen.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { View } from '../components/Themed';
 import FavoriteCard from '../components/shared/FavoriteCard';
 import AppStyles from '../AppStyles';
+import { supperClub } from '../theme/supperClub';
 import { useFavorites } from '../hooks/useFavorites';
 import { MaterialIcons, Ionicons } from '@expo/vector-icons';
 import { FavoriteItem } from '../types/favorites';
@@ -62,15 +63,15 @@ const FavoritesScreen: React.FC = () => {
                 ]}
                 onPress={toggleSearch}
                 android_ripple={{
-                  color: AppStyles.color.background,
+                  color: supperClub.borderSoft,
                   radius: 20,
                   borderless: true,
                 }}
               >
-                <MaterialIcons 
-                  name={showSearch ? "close" : "search"} 
-                  size={24} 
-                  color={AppStyles.color.primary} 
+                <MaterialIcons
+                  name={showSearch ? "close" : "search"}
+                  size={24}
+                  color={supperClub.gold}
                 />
               </Pressable>
             )}
@@ -78,10 +79,10 @@ const FavoritesScreen: React.FC = () => {
 
           {showSearch && (
             <View style={styles.searchContainer}>
-              <MaterialIcons 
-                name="search" 
-                size={20} 
-                color={AppStyles.color.greylight} 
+              <MaterialIcons
+                name="search"
+                size={20}
+                color={supperClub.textMuted}
                 style={styles.searchIcon}
               />
               <TextInput
@@ -91,17 +92,17 @@ const FavoritesScreen: React.FC = () => {
                 onChangeText={setSearchQuery}
                 autoFocus
                 returnKeyType="search"
-                placeholderTextColor={AppStyles.color.greylight}
+                placeholderTextColor={supperClub.textMuted}
               />
               {searchQuery.length > 0 && (
                 <Pressable
                   onPress={() => setSearchQuery('')}
                   style={styles.clearButton}
                 >
-                  <MaterialIcons 
-                    name="clear" 
-                    size={20} 
-                    color={AppStyles.color.greylight} 
+                  <MaterialIcons
+                    name="clear"
+                    size={20}
+                    color={supperClub.textMuted}
                   />
                 </Pressable>
               )}
@@ -120,7 +121,7 @@ const FavoritesScreen: React.FC = () => {
           />
         ) : favorites.length === 0 ? (
           <View style={styles.emptyState}>
-            <Ionicons name="heart-outline" size={64} color={AppStyles.color.gray300} />
+            <Ionicons name="heart-outline" size={64} color={supperClub.textMuted} />
             <Text style={styles.emptyTitle}>No favorites yet</Text>
             <Text style={styles.emptyText}>
               Search for restaurants and tap the heart icon to save your favorites!
@@ -128,7 +129,7 @@ const FavoritesScreen: React.FC = () => {
           </View>
         ) : (
           <View style={styles.emptyState}>
-            <MaterialIcons name="search-off" size={64} color={AppStyles.color.gray300} />
+            <MaterialIcons name="search-off" size={64} color={supperClub.textMuted} />
             <Text style={styles.emptyTitle}>No matches found</Text>
             <Text style={styles.emptyText}>
               Try adjusting your search or browse all {favorites.length} favorites.
@@ -145,15 +146,15 @@ const FavoritesScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: supperClub.background,
   },
   header: {
     paddingTop: 20,
     paddingBottom: 16,
     paddingHorizontal: 16,
-    backgroundColor: AppStyles.color.white,
+    backgroundColor: supperClub.surfaceElevated,
     borderBottomWidth: 1,
-    borderBottomColor: AppStyles.color.background,
+    borderBottomColor: supperClub.borderSoft,
   },
   titleRow: {
     flexDirection: 'row',
@@ -166,16 +167,16 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     marginBottom: 4,
   },
   subtitle: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
   },
   searchButton: {
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderRadius: 24,
     width: 48,
     height: 48,
@@ -193,7 +194,7 @@ const styles = StyleSheet.create({
   searchContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderRadius: 12,
     marginTop: 12,
     paddingHorizontal: 12,
@@ -206,7 +207,7 @@ const styles = StyleSheet.create({
     flex: 1,
     fontSize: 16,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.black,
+    color: supperClub.text,
     paddingVertical: 4,
   },
   clearButton: {
@@ -232,14 +233,14 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 24,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     textAlign: 'center',
     marginBottom: 12,
   },
   emptyText: {
     fontSize: 16,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
     textAlign: 'center',
     lineHeight: 24,
   },

--- a/screens/FiltersModal.tsx
+++ b/screens/FiltersModal.tsx
@@ -11,7 +11,8 @@ import {
 } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { Ionicons } from '@expo/vector-icons';
-import { colors, spacing, radius, typography } from '../theme';
+import { spacing, radius, typography } from '../theme';
+import { supperClub } from '../theme/supperClub';
 
 interface FiltersModalProps {
   visible: boolean;
@@ -77,7 +78,7 @@ export const FiltersModal: React.FC<FiltersModalProps> = ({
           <Text style={styles.title}>Filters</Text>
 
           <Pressable onPress={onClose} hitSlop={8}>
-            <Ionicons name="close" size={28} color={colors.gray700} />
+            <Ionicons name="close" size={28} color={supperClub.text} />
           </Pressable>
         </View>
 
@@ -143,8 +144,8 @@ export const FiltersModal: React.FC<FiltersModalProps> = ({
               <Switch
                 value={openNow}
                 onValueChange={setOpenNow}
-                trackColor={{ false: colors.gray300, true: colors.primary }}
-                thumbColor={colors.white}
+                trackColor={{ false: 'rgba(255,255,255,0.12)', true: supperClub.primary }}
+                thumbColor={supperClub.textPrimary}
               />
             </View>
           </View>
@@ -166,7 +167,7 @@ export const FiltersModal: React.FC<FiltersModalProps> = ({
                     name="star"
                     size={16}
                     color={
-                      minRating === rating ? colors.white : colors.warning
+                      minRating === rating ? supperClub.textPrimary : supperClub.gold
                     }
                   />
                   <Text
@@ -203,7 +204,7 @@ export const FiltersModal: React.FC<FiltersModalProps> = ({
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: colors.background,
+    backgroundColor: supperClub.background,
   },
   header: {
     flexDirection: 'row',
@@ -212,15 +213,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
     borderBottomWidth: 1,
-    borderBottomColor: colors.border,
+    borderBottomColor: supperClub.border,
   },
   clearButton: {
     ...typography.callout,
-    color: colors.primary,
+    color: supperClub.gold,
   },
   title: {
     ...typography.headline,
-    color: colors.gray900,
+    color: supperClub.textPrimary,
   },
   content: {
     flex: 1,
@@ -229,11 +230,11 @@ const styles = StyleSheet.create({
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.lg,
     borderBottomWidth: 1,
-    borderBottomColor: colors.border,
+    borderBottomColor: supperClub.border,
   },
   sectionTitle: {
     ...typography.headline,
-    color: colors.gray900,
+    color: supperClub.textPrimary,
     marginBottom: spacing.md,
   },
   priceGrid: {
@@ -243,22 +244,22 @@ const styles = StyleSheet.create({
   priceButton: {
     flex: 1,
     paddingVertical: spacing.md,
-    backgroundColor: colors.gray100,
+    backgroundColor: 'rgba(255,255,255,0.05)',
     borderRadius: radius.md,
     borderWidth: 2,
     borderColor: 'transparent',
     alignItems: 'center',
   },
   priceButtonSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   priceButtonText: {
     ...typography.headline,
-    color: colors.gray700,
+    color: supperClub.text,
   },
   priceButtonTextSelected: {
-    color: colors.white,
+    color: supperClub.textPrimary,
   },
   distanceGrid: {
     flexDirection: 'row',
@@ -268,21 +269,21 @@ const styles = StyleSheet.create({
   distanceButton: {
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.lg,
-    backgroundColor: colors.gray100,
+    backgroundColor: 'rgba(255,255,255,0.05)',
     borderRadius: radius.md,
     borderWidth: 2,
     borderColor: 'transparent',
   },
   distanceButtonSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   distanceButtonText: {
     ...typography.callout,
-    color: colors.gray700,
+    color: supperClub.text,
   },
   distanceButtonTextSelected: {
-    color: colors.white,
+    color: supperClub.textPrimary,
   },
   toggleRow: {
     flexDirection: 'row',
@@ -291,7 +292,7 @@ const styles = StyleSheet.create({
   },
   toggleLabel: {
     ...typography.headline,
-    color: colors.gray900,
+    color: supperClub.textPrimary,
   },
   ratingGrid: {
     flexDirection: 'row',
@@ -303,37 +304,37 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: spacing.sm,
     paddingHorizontal: spacing.md,
-    backgroundColor: colors.gray100,
+    backgroundColor: 'rgba(255,255,255,0.05)',
     borderRadius: radius.md,
     borderWidth: 2,
     borderColor: 'transparent',
     gap: spacing.xs,
   },
   ratingButtonSelected: {
-    backgroundColor: colors.primary,
-    borderColor: colors.primary,
+    backgroundColor: supperClub.primary,
+    borderColor: supperClub.primary,
   },
   ratingButtonText: {
     ...typography.callout,
-    color: colors.gray700,
+    color: supperClub.text,
   },
   ratingButtonTextSelected: {
-    color: colors.white,
+    color: supperClub.textPrimary,
   },
   footer: {
     paddingHorizontal: spacing.md,
     paddingVertical: spacing.md,
     borderTopWidth: 1,
-    borderTopColor: colors.border,
+    borderTopColor: supperClub.border,
   },
   applyButton: {
-    backgroundColor: colors.primary,
+    backgroundColor: supperClub.primary,
     borderRadius: radius.md,
     paddingVertical: spacing.md,
     alignItems: 'center',
     ...Platform.select({
       ios: {
-        shadowColor: colors.shadow,
+        shadowColor: 'rgba(0,0,0,0.6)',
         shadowOffset: { width: 0, height: 2 },
         shadowOpacity: 0.2,
         shadowRadius: 8,
@@ -348,6 +349,6 @@ const styles = StyleSheet.create({
   },
   applyButtonText: {
     ...typography.headline,
-    color: colors.white,
+    color: supperClub.textPrimary,
   },
 });

--- a/screens/HistoryScreen.tsx
+++ b/screens/HistoryScreen.tsx
@@ -4,6 +4,7 @@ import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
 import { MaterialIcons } from '@expo/vector-icons';
 import AppStyles from '../AppStyles';
+import { supperClub } from '../theme/supperClub';
 import { useHistory } from '../hooks/useHistory';
 import { HistoryItem } from '../types/favorites';
 import { RootContext } from '../context/RootContext';
@@ -109,7 +110,7 @@ const HistoryScreen: React.FC = () => {
       ]}
       onPress={() => handleHistoryItemPress(item)}
       android_ripple={{
-        color: AppStyles.color.background,
+        color: supperClub.borderSoft,
         radius: 200,
       }}
     >
@@ -123,7 +124,7 @@ const HistoryScreen: React.FC = () => {
               <MaterialIcons
                 name={item.source === 'spin' ? 'casino' : 'touch-app'}
                 size={12}
-                color={AppStyles.color.white}
+                color={'#FFFFFF'}
               />
               <Text style={styles.sourceBadgeText}>
                 {item.source === 'spin' ? 'Spin' : 'Manual'}
@@ -139,13 +140,13 @@ const HistoryScreen: React.FC = () => {
           <View style={styles.contextContainer}>
             {item.context.searchTerm && (
               <Text style={styles.contextText}>
-                <MaterialIcons name="search" size={14} color={AppStyles.color.greylight} />
+                <MaterialIcons name="search" size={14} color={supperClub.textMuted} />
                 {' '}{item.context.searchTerm}
               </Text>
             )}
             {item.context.locationText && (
               <Text style={styles.contextText}>
-                <MaterialIcons name="location-on" size={14} color={AppStyles.color.greylight} />
+                <MaterialIcons name="location-on" size={14} color={supperClub.textMuted} />
                 {' '}{item.context.locationText}
               </Text>
             )}
@@ -177,11 +178,11 @@ const HistoryScreen: React.FC = () => {
             ]}
             onPress={() => handleHistoryItemPress(item)}
             android_ripple={{
-              color: AppStyles.color.white,
+              color: '#FFFFFF',
               radius: 20,
             }}
           >
-            <MaterialIcons name="open-in-new" size={16} color={AppStyles.color.white} />
+            <MaterialIcons name="open-in-new" size={16} color={'#FFFFFF'} />
             <Text style={styles.actionButtonTextWhite}>Open</Text>
           </Pressable>
 
@@ -194,11 +195,11 @@ const HistoryScreen: React.FC = () => {
               ]}
               onPress={() => handleSpinAgain(item)}
               android_ripple={{
-                color: AppStyles.color.background,
+                color: supperClub.borderSoft,
                 radius: 20,
               }}
             >
-              <MaterialIcons name="casino" size={16} color={AppStyles.color.primary} />
+              <MaterialIcons name="casino" size={16} color={supperClub.gold} />
               <Text style={styles.actionButtonText}>Spin Again</Text>
             </Pressable>
           )}
@@ -229,15 +230,15 @@ const HistoryScreen: React.FC = () => {
                 ]}
                 onPress={handleClearHistory}
                 android_ripple={{
-                  color: AppStyles.color.background,
+                  color: supperClub.borderSoft,
                   radius: 20,
                   borderless: true,
                 }}
               >
-                <MaterialIcons 
-                  name="clear-all" 
-                  size={24} 
-                  color={AppStyles.color.error} 
+                <MaterialIcons
+                  name="clear-all"
+                  size={24}
+                  color={supperClub.error}
                 />
               </Pressable>
             )}
@@ -255,7 +256,7 @@ const HistoryScreen: React.FC = () => {
           />
         ) : (
           <View style={styles.emptyState}>
-            <MaterialIcons name="history" size={64} color={AppStyles.color.gray300} />
+            <MaterialIcons name="history" size={64} color={supperClub.textMuted} />
             <Text style={styles.emptyTitle}>No spins yet</Text>
             <Text style={styles.emptyText}>
               Try the roulette feature to discover new restaurants. Your selections will appear here with options to revisit or spin again with the same criteria!
@@ -272,15 +273,15 @@ const HistoryScreen: React.FC = () => {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: supperClub.background,
   },
   header: {
     paddingTop: 20,
     paddingBottom: 16,
     paddingHorizontal: 16,
-    backgroundColor: AppStyles.color.white,
+    backgroundColor: supperClub.surfaceElevated,
     borderBottomWidth: 1,
-    borderBottomColor: AppStyles.color.background,
+    borderBottomColor: supperClub.borderSoft,
   },
   titleRow: {
     flexDirection: 'row',
@@ -293,16 +294,16 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 28,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     marginBottom: 4,
   },
   subtitle: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
   },
   clearButton: {
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderRadius: 24,
     width: 48,
     height: 48,
@@ -325,7 +326,7 @@ const styles = StyleSheet.create({
     paddingVertical: 16,
   },
   historyItem: {
-    backgroundColor: AppStyles.color.white,
+    backgroundColor: supperClub.surfaceElevated,
     borderRadius: 12,
     marginBottom: 12,
     shadowColor: AppStyles.color.shadow,
@@ -353,20 +354,20 @@ const styles = StyleSheet.create({
   itemName: {
     fontSize: 18,
     fontFamily: AppStyles.fonts.semiBold,
-    color: AppStyles.color.black,
+    color: '#FFFFFF',
     marginBottom: 4,
   },
   sourceBadge: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: AppStyles.color.primary,
+    backgroundColor: supperClub.primary,
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 12,
     alignSelf: 'flex-start',
   },
   sourceBadgeText: {
-    color: AppStyles.color.white,
+    color: '#FFFFFF',
     fontSize: 12,
     fontFamily: AppStyles.fonts.medium,
     marginLeft: 4,
@@ -374,7 +375,7 @@ const styles = StyleSheet.create({
   timestamp: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
   },
   contextContainer: {
     marginBottom: 12,
@@ -382,7 +383,7 @@ const styles = StyleSheet.create({
   contextText: {
     fontSize: 14,
     fontFamily: AppStyles.fonts.regular,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
     marginBottom: 4,
   },
   filtersContainer: {
@@ -392,7 +393,7 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   filterChip: {
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     paddingHorizontal: 8,
     paddingVertical: 4,
     borderRadius: 8,
@@ -400,7 +401,7 @@ const styles = StyleSheet.create({
   filterChipText: {
     fontSize: 12,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greydark,
+    color: supperClub.text,
   },
   actions: {
     flexDirection: 'row',
@@ -422,21 +423,21 @@ const styles = StyleSheet.create({
     elevation: 2,
   },
   openButton: {
-    backgroundColor: AppStyles.color.primary,
+    backgroundColor: supperClub.primary,
   },
   spinAgainButton: {
-    backgroundColor: AppStyles.color.background,
+    backgroundColor: 'rgba(255, 255, 255, 0.05)',
     borderWidth: 1,
-    borderColor: AppStyles.color.primary,
+    borderColor: supperClub.gold,
   },
   actionButtonTextWhite: {
-    color: AppStyles.color.white,
+    color: '#FFFFFF',
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
     marginLeft: 4,
   },
   actionButtonText: {
-    color: AppStyles.color.primary,
+    color: supperClub.gold,
     fontSize: 14,
     fontFamily: AppStyles.fonts.medium,
     marginLeft: 4,
@@ -454,14 +455,14 @@ const styles = StyleSheet.create({
   emptyTitle: {
     fontSize: 24,
     fontFamily: AppStyles.fonts.bold,
-    color: AppStyles.color.greydark,
+    color: '#FFFFFF',
     textAlign: 'center',
     marginBottom: 12,
   },
   emptyText: {
     fontSize: 16,
     fontFamily: AppStyles.fonts.medium,
-    color: AppStyles.color.greylight,
+    color: supperClub.textMuted,
     textAlign: 'center',
     lineHeight: 24,
   },

--- a/screens/ResultsShowScreen.tsx
+++ b/screens/ResultsShowScreen.tsx
@@ -16,6 +16,7 @@ import { ResultsShowScreenProps } from "../types";
 import { BusinessProps } from "../hooks/useResults";
 import { FontAwesome, MaterialIcons } from "@expo/vector-icons";
 import AppStyles from "../AppStyles";
+import { supperClub } from "../theme/supperClub";
 import { View } from "../components/Themed";
 import StarRating from "../components/shared/StarRating";
 import Config from "../Config";
@@ -159,7 +160,7 @@ const styles = StyleSheet.create({
 		paddingVertical: 24,
 	},
 	button: {
-		backgroundColor: `rgba(255, 255, 255, 0.69)`,
+		backgroundColor: supperClub.surfaceElevated,
 		flexDirection: `row`,
 		shadowColor: AppStyles.input.shadow,
 		...AppStyles.ButtonPressable,
@@ -169,6 +170,7 @@ const styles = StyleSheet.create({
 		marginRight: 10,
 	},
 	container: {
+		backgroundColor: supperClub.background,
 		flex: 1,
 	},
 	imageContainer: {
@@ -193,7 +195,7 @@ const styles = StyleSheet.create({
 		position: `absolute`,
 	},
 	title: {
-		color: AppStyles.color.white,
+		color: "#FFFFFF",
 		fontSize: 24,
 		fontWeight: `bold`,
 		left: 16,

--- a/screens/ResultsShowScreen.tsx
+++ b/screens/ResultsShowScreen.tsx
@@ -102,7 +102,7 @@ const ResultsShowScreen = ({ navigation, route }: ResultsShowScreenProps<`Result
 				<Text style={styles.price}><OpenSign is_open_now={is_open_now} /></Text>
 				<View style={styles.starRating}>
 					<StarRating rating={result.rating} shadow />
-					<Text>{result.review_count} Review{result.review_count > 1 ? `s` : ``}</Text>
+					<Text style={styles.text}>{result.review_count} Review{result.review_count > 1 ? `s` : ``}</Text>
 				</View>
 			</View>
 
@@ -142,12 +142,12 @@ const ResultsShowScreen = ({ navigation, route }: ResultsShowScreenProps<`Result
 						name={`phone-in-talk`}
 						size={20}
 					/>
-					<Text>{result.display_phone}</Text>
+					<Text style={styles.text}>{result.display_phone}</Text>
 				</Pressable>
 			</View>
 			<ScrollView style={styles.codeblock}>
-				<Text>is_closed: {result.is_closed.toString()}</Text>
-				<Text>Address: {result.location.display_address.join(`, `)}</Text>
+				<Text style={styles.text}>is_closed: {result.is_closed.toString()}</Text>
+				<Text style={styles.text}>Address: {result.location.display_address.join(`, `)}</Text>
 			</ScrollView>
 		</Animated.View>
 	);
@@ -168,6 +168,9 @@ const styles = StyleSheet.create({
 	codeblock: {
 		marginLeft: 10,
 		marginRight: 10,
+	},
+	text: {
+		color: supperClub.text,
 	},
 	container: {
 		backgroundColor: supperClub.background,


### PR DESCRIPTION
## Summary

Completes the global Supper Club promotion — the last light-theme surfaces now match Home / Search / results / detail. Done per-screen (not a blind global token swap) to avoid the white-bg-vs-text and primary-icon-vs-button contrast traps, via parallel agents over disjoint files.

| Screen | Refs | Notes |
|--------|------|-------|
| FiltersSheet | 39 | selected chips + Apply → magenta, icons → gold, include/exclude kept semantic green/red, Reset muted, switch tracks solid. **28 tests pass.** |
| HistoryScreen | 35 | cards → surfaceElevated, badges/open → magenta, spin-again → gold |
| FiltersModal | 30 | migrated off `theme/colors.*` → supperClub; grep-clean |
| FavoritesScreen | 18 | espresso ground, gold search accent |
| BlockedScreen | 18 | dark ground, unblock affordance visible |
| ResultsShowScreen | 4 | container ground + button surface |

Preserved everywhere: structure, props, testIDs, handlers, filter logic; brand `yelp`/`phone` colors; shadows. `NotFoundScreen` had no colors (skipped).

## Verification
`yarn test`: **40 suites / 368 tests / 5 snapshots green.** Each file also grep-/tsc-clean per agent.

## Note
Two **pre-existing** TS issues surfaced in `ResultsShowScreen.tsx` (missing `ResultsShowScreenProps` export, `AppStyles.input.shadow`) — not introduced here, flagged for a separate cleanup.