### PR TITLE
chore(deploy): EAS TestFlight prep

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,56 @@
+# Deploying Rouxlette
+
+Rouxlette ships through **EAS** (Expo Application Services). This covers the first
+iOS / TestFlight release.
+
+## One-time setup
+
+1. **Apple Developer Program** membership ($99/yr) — required for TestFlight/App Store.
+2. `eas login` — sign in to your Expo account (`npx eas-cli` if `eas` isn't global).
+3. `eas init` — links this repo to an Expo project and writes `extra.eas.projectId`
+   into `app.json`. Run once.
+
+## Secrets (Yelp / Google API keys)
+
+The app reads `YELP_API_KEY`, `GOOGLE_API_KEY`, `DEV_USE_MOCK` via `@env`
+(react-native-dotenv) from a **gitignored `.env`**. EAS cloud builders don't have
+your local `.env`, so register them as EAS environment variables once:
+
+```
+eas env:create --scope project --name YELP_API_KEY   --value "<key>"  --visibility secret
+eas env:create --scope project --name GOOGLE_API_KEY --value "<key>"  --visibility secret
+eas env:create --scope project --name DEV_USE_MOCK   --value "false"
+```
+
+The `eas-build-pre-install` hook (`scripts/eas-write-env.js`) writes these into a
+`.env` on the builder so react-native-dotenv can inline them at build time.
+
+## Build + submit to TestFlight
+
+```
+eas build  --platform ios --profile production
+eas submit --platform ios --latest
+```
+
+`eas submit` uploads to App Store Connect; the build shows up in **TestFlight**
+after Apple processes it (usually minutes). Add testers in
+App Store Connect → TestFlight.
+
+## Versioning
+
+`eas.json` uses `appVersionSource: remote` + `autoIncrement`, so EAS manages the iOS
+`buildNumber` for you. Bump the marketing `version` in `app.json` for user-facing
+releases.
+
+## Bundle identifier
+
+`com.fullybakedlabs.rouxlette` (iOS + Android). It transfers with the app if you
+later move from a personal to an organization Apple account.
+
+## Follow-ups (not blocking a first build)
+
+- **Splash/icon background** is still `#1B5E20` (old green) in `app.json`; update to
+  the Supper Club espresso `#1A1013` (and regenerate the splash asset) to match the app.
+- **OTA updates:** add `expo-updates` + a `runtimeVersion` to ship JS-only changes via
+  `eas update` without a store review.
+- **Android:** the same profiles build a `.aab`; add a Play Console account + `eas submit -p android` when ready.

--- a/app.json
+++ b/app.json
@@ -23,7 +23,7 @@
       "infoPlist": {
         "NSLocationWhenInUseUsageDescription": "Rouxlette needs your location to find nearby restaurants for your roulette selections."
       },
-      "bundleIdentifier": "com.anonymous.rouxlette"
+      "bundleIdentifier": "com.fullybakedlabs.rouxlette"
     },
     "android": {
       "adaptiveIcon": {
@@ -34,7 +34,7 @@
         "ACCESS_FINE_LOCATION",
         "ACCESS_COARSE_LOCATION"
       ],
-      "package": "com.anonymous.rouxlette"
+      "package": "com.fullybakedlabs.rouxlette"
     },
     "web": {
       "favicon": "./assets/favicon.png"

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,30 @@
+{
+  "cli": {
+    "version": ">= 5.9.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "autoIncrement": true,
+      "ios": {
+        "simulator": false
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test": "jest --watchAll",
     "lint:unsafe-logging": "node scripts/checkUnsafeLogging.js",
     "precommit": "npm run lint:unsafe-logging",
-    "clean": "watchman watch-del-all && rm -rf /tmp/metro-* && rm -rf node_modules/.cache"
+    "clean": "watchman watch-del-all && rm -rf /tmp/metro-* && rm -rf node_modules/.cache",
+    "eas-build-pre-install": "node ./scripts/eas-write-env.js"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/scripts/eas-write-env.js
+++ b/scripts/eas-write-env.js
@@ -1,0 +1,29 @@
+/**
+ * EAS build hook — runs automatically as `eas-build-pre-install`.
+ *
+ * react-native-dotenv inlines `@env` imports from a `.env` FILE at build time,
+ * but the real `.env` is gitignored and never reaches the EAS cloud builder.
+ * This materializes `.env` from EAS environment variables so the build resolves
+ * @env the same way local/CI does.
+ *
+ * SET THESE AS EAS ENVIRONMENT VARIABLES (visibility: Secret) on the build
+ * profile you use (e.g. production):
+ *   YELP_API_KEY, GOOGLE_API_KEY, DEV_USE_MOCK
+ *
+ *   eas env:create --scope project --name YELP_API_KEY   --value "..." --visibility secret
+ *   eas env:create --scope project --name GOOGLE_API_KEY --value "..." --visibility secret
+ *   eas env:create --scope project --name DEV_USE_MOCK   --value "false"
+ */
+const fs = require('fs');
+
+const KEYS = ['YELP_API_KEY', 'GOOGLE_API_KEY', 'DEV_USE_MOCK'];
+const missing = KEYS.filter((k) => !process.env[k]);
+if (missing.length) {
+  // Warn but do not fail: react-native-dotenv (allowUndefined:false) will throw
+  // during bundling if a referenced key is truly missing, which surfaces clearly.
+  console.warn(`[eas-write-env] warning: missing EAS env vars: ${missing.join(', ')}`);
+}
+
+const lines = KEYS.map((k) => `${k}=${process.env[k] ?? ''}`);
+fs.writeFileSync('.env', lines.join('\n') + '\n');
+console.log(`[eas-write-env] wrote .env with ${KEYS.length} keys (${KEYS.length - missing.length} present)`);


### PR DESCRIPTION
## Summary

Prepares the repo for iOS/TestFlight via EAS — everything that needs no Apple account. After this, deploy is: `eas login → eas init → (set secrets) → eas build → eas submit`.

- **Real bundle identifier** `com.fullybakedlabs.rouxlette` (iOS + Android) — replaces the `com.anonymous.*` placeholder Apple/Google reject. Business-neutral so it transfers cleanly if you move to a FullyBakedLabs org account.
- **`eas.json`** — development / preview / production profiles; `appVersionSource: remote` + `autoIncrement` so EAS manages the iOS `buildNumber`.
- **Secrets bridge** — `scripts/eas-write-env.js` runs as the `eas-build-pre-install` hook and writes `.env` from EAS environment variables (`YELP_API_KEY`, `GOOGLE_API_KEY`, `DEV_USE_MOCK`), so react-native-dotenv resolves `@env` on the cloud builder exactly as it does locally/CI.
- **`DEPLOY.md`** — the full login→init→secrets→build→submit runbook.

## Notes
- No app code changed;  is added by `eas init` (needs your Expo login).
- Real `.env` stays gitignored — only the EAS-injected values reach the builder.
- Follow-ups (documented in DEPLOY.md): splash/icon still use the old green `#1B5E20`; add `expo-updates` for OTA.