### PR TITLE
chore(theme): splash/icon background to Supper Club espresso

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
     "splash": {
       "image": "./assets/splash.png",
       "resizeMode": "cover",
-      "backgroundColor": "#1B5E20"
+      "backgroundColor": "#1A1013"
     },
     "updates": {
       "fallbackToCacheTimeout": 0
@@ -28,7 +28,7 @@
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#1B5E20"
+        "backgroundColor": "#1A1013"
       },
       "permissions": [
         "ACCESS_FINE_LOCATION",
@@ -47,7 +47,7 @@
       [
         "expo-splash-screen",
         {
-          "backgroundColor": "#1B5E20",
+          "backgroundColor": "#1A1013",
           "image": "./assets/splash.png",
           "imageWidth": 200
         }


### PR DESCRIPTION
Update splash, Android adaptive-icon, and expo-splash-screen `backgroundColor` from the old green `#1B5E20` to Supper Club espresso `#1A1013` so the launch screen matches the app.

Config-only (app.json). The `splash.png` / `adaptive-icon.png` image art still carries the old green — regenerate those assets for full consistency (follow-up).