### PR TITLE
chore(deploy): eas env:set + environment mapping

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -14,13 +14,19 @@ iOS / TestFlight release.
 
 The app reads `YELP_API_KEY`, `GOOGLE_API_KEY`, `DEV_USE_MOCK` via `@env`
 (react-native-dotenv) from a **gitignored `.env`**. EAS cloud builders don't have
-your local `.env`, so register them as EAS environment variables once:
+your local `.env`, so register them as EAS environment variables once. EAS scopes
+env vars to an **environment**; the `production` build profile maps to the
+`production` environment (set in `eas.json`), so set them there:
 
 ```
-eas env:create --scope project --name YELP_API_KEY   --value "<key>"  --visibility secret
-eas env:create --scope project --name GOOGLE_API_KEY --value "<key>"  --visibility secret
-eas env:create --scope project --name DEV_USE_MOCK   --value "false"
+eas env:set --environment production --name YELP_API_KEY   --value "<key>"  --visibility secret
+eas env:set --environment production --name GOOGLE_API_KEY --value "<key>"  --visibility secret
+eas env:set --environment production --name DEV_USE_MOCK   --value "false"
 ```
+
+(`eas env:set` replaces the deprecated `eas env:create`. Repeat with
+`--environment preview` / `development` if you build those profiles. Never paste a
+real key into a shared terminal/chat — if you do, rotate it.)
 
 The `eas-build-pre-install` hook (`scripts/eas-write-env.js`) writes these into a
 `.env` on the builder so react-native-dotenv can inline them at build time.

--- a/eas.json
+++ b/eas.json
@@ -7,18 +7,21 @@
     "development": {
       "developmentClient": true,
       "distribution": "internal",
+      "environment": "development",
       "ios": {
         "simulator": true
       }
     },
     "preview": {
       "distribution": "internal",
+      "environment": "preview",
       "ios": {
         "simulator": false
       }
     },
     "production": {
       "autoIncrement": true,
+      "environment": "production",
       "ios": {
         "simulator": false
       }


### PR DESCRIPTION
Follow-up to the EAS prep (#44):

- `eas env:create` is deprecated → docs now use **`eas env:set --environment production`**.
- `eas.json`: each build profile now declares its `environment` (development/preview/production) so the environment-scoped EAS secrets actually get injected at build time.
- Added a note to never paste real keys into a shared terminal/chat (rotate if exposed).