### PR TITLE
chore(deploy): commit eas init output + iOS encryption exemption

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,8 @@
     "ios": {
       "supportsTablet": true,
       "infoPlist": {
-        "NSLocationWhenInUseUsageDescription": "Rouxlette needs your location to find nearby restaurants for your roulette selections."
+        "NSLocationWhenInUseUsageDescription": "Rouxlette needs your location to find nearby restaurants for your roulette selections.",
+        "ITSAppUsesNonExemptEncryption": false
       },
       "bundleIdentifier": "com.fullybakedlabs.rouxlette"
     },
@@ -32,7 +33,9 @@
       },
       "permissions": [
         "ACCESS_FINE_LOCATION",
-        "ACCESS_COARSE_LOCATION"
+        "ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.ACCESS_FINE_LOCATION"
       ],
       "package": "com.fullybakedlabs.rouxlette"
     },
@@ -52,6 +55,11 @@
           "imageWidth": 200
         }
       ]
-    ]
+    ],
+    "extra": {
+      "eas": {
+        "projectId": "9ce1b098-76b7-4b79-a11a-bb337043c712"
+      }
+    }
   }
 }


### PR DESCRIPTION
Persists the `app.json` changes generated during the first EAS build so future/clean builds are reproducible:

- **`extra.eas.projectId`** — links the repo to the EAS project (from `eas init`). Must be tracked.
- **`ITSAppUsesNonExemptEncryption: false`** — declares standard-HTTPS-only encryption, so App Store Connect stops prompting for export compliance each build.
- **Android location permissions** — `expo-location` added fully-qualified forms alongside the short ones (redundant but harmless; trivial cleanup later if desired).