### PR TITLE
fix(results): wheel-pick hero shows the actual spun winner (#48)

### DIFF
--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -162,4 +162,23 @@ describe('SearchScreen', () => {
     expect(queryByText(/The wheel picked/)).toBeNull();
     expect(getByText('Top result')).toBeTruthy();
   });
+
+  it('ignores a stale spin winner not present in the current results', () => {
+    const state = {
+      ...mockInitialState,
+      results: [
+        { id: 'a', name: 'Alpha Cafe', categories: [] },
+        { id: 'b', name: 'Beta Bistro', categories: [] },
+      ] as any,
+      // A prior spin from a different result set — its winner isn't in these results.
+      spinHistory: [
+        { restaurant: { id: 'z', name: 'Zeta Diner', categories: [] }, timestamp: 1 },
+      ] as any,
+    };
+    const { queryByText, getByText, getByTestId } = renderSearch(state);
+    // No stale "wheel picked" badge; hero falls back to the top result (A).
+    expect(queryByText(/The wheel picked/)).toBeNull();
+    expect(getByText('Top result')).toBeTruthy();
+    expect(within(getByTestId('restaurant-card-a')).getByText(/Spin again/)).toBeTruthy();
+  });
 });

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, within } from '@testing-library/react-native';
 import { SearchScreen } from '../../screens/SearchScreen';
 import { RootContext } from '../../context/RootContext';
 import { mockInitialState } from '../mocks/mockState';
@@ -128,5 +128,38 @@ describe('SearchScreen', () => {
     const { getByTestId } = renderSearch(state);
     expect(getByTestId('restaurant-card-a')).toBeTruthy();
     expect(getByTestId('restaurant-card-b')).toBeTruthy();
+  });
+
+  it('makes the actual spun winner the "wheel picked" hero, not the first result', () => {
+    const state = {
+      ...mockInitialState,
+      results: [
+        { id: 'a', name: 'Alpha Cafe', categories: [] },
+        { id: 'b', name: 'Beta Bistro', categories: [] },
+      ] as any,
+      // The wheel landed on B, which is NOT the first result.
+      spinHistory: [
+        { restaurant: { id: 'b', name: 'Beta Bistro', categories: [] }, timestamp: 1 },
+      ] as any,
+    };
+    const { getByTestId } = renderSearch(state);
+    // The hero card carries the wheel badge + the hero-only "Spin again" action,
+    // and it must be the winner (B), not the first result (A).
+    const heroB = getByTestId('restaurant-card-b');
+    expect(within(heroB).getByText(/The wheel picked/)).toBeTruthy();
+    expect(within(heroB).getByText(/Spin again/)).toBeTruthy();
+    // A is a plain row — no hero-only action.
+    expect(within(getByTestId('restaurant-card-a')).queryByText(/Spin again/)).toBeNull();
+  });
+
+  it('does not claim "wheel picked" when there was no spin this session', () => {
+    const state = {
+      ...mockInitialState,
+      results: [{ id: 'a', name: 'Alpha Cafe', categories: [] }] as any,
+      spinHistory: [] as any,
+    };
+    const { queryByText, getByText } = renderSearch(state);
+    expect(queryByText(/The wheel picked/)).toBeNull();
+    expect(getByText('Top result')).toBeTruthy();
   });
 });

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -68,14 +68,16 @@ export const SearchScreen: React.FC = () => {
 
     // The results hero is the wheel's ACTUAL pick (most recent spin), not just
     // the first result — otherwise the "The wheel picked" badge lands on the
-    // wrong restaurant (#48). Prefer the winner from the current list (so
-    // favorite/block state matches); surface it even if filters would hide it.
-    // With no spin this session, fall back to the top result with a neutral badge.
+    // wrong restaurant (#48). Gate it on the pick being present in the CURRENT
+    // filtered results: this keeps the hero's actions resolvable (it's a real
+    // item from `restaurants`) and avoids a STALE badge after a fresh search,
+    // since spinHistory persists across sessions. Otherwise: neutral top result.
     const lastSpinWinner = state.spinHistory?.[0]?.restaurant;
-    const heroRestaurant = lastSpinWinner
-        ? (restaurants.find(r => r.id === lastSpinWinner.id) ?? businessToRestaurant(lastSpinWinner))
-        : restaurants[0];
-    const heroIsWheelPick = !!lastSpinWinner;
+    const winnerInResults = lastSpinWinner
+        ? restaurants.find(r => r.id === lastSpinWinner.id)
+        : undefined;
+    const heroRestaurant = winnerInResults ?? restaurants[0];
+    const heroIsWheelPick = !!winnerInResults;
     const rowRestaurants = restaurants.filter(r => r.id !== heroRestaurant?.id);
 
     // Build active filters array for display

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -66,6 +66,18 @@ export const SearchScreen: React.FC = () => {
 
     const restaurants = filteredBusinesses.map(businessToRestaurant);
 
+    // The results hero is the wheel's ACTUAL pick (most recent spin), not just
+    // the first result — otherwise the "The wheel picked" badge lands on the
+    // wrong restaurant (#48). Prefer the winner from the current list (so
+    // favorite/block state matches); surface it even if filters would hide it.
+    // With no spin this session, fall back to the top result with a neutral badge.
+    const lastSpinWinner = state.spinHistory?.[0]?.restaurant;
+    const heroRestaurant = lastSpinWinner
+        ? (restaurants.find(r => r.id === lastSpinWinner.id) ?? businessToRestaurant(lastSpinWinner))
+        : restaurants[0];
+    const heroIsWheelPick = !!lastSpinWinner;
+    const rowRestaurants = restaurants.filter(r => r.id !== heroRestaurant?.id);
+
     // Build active filters array for display
     const activeFilters: ActiveFilter[] = [];
 
@@ -391,7 +403,7 @@ export const SearchScreen: React.FC = () => {
             {/* Results — hero top pick + compact rows (Supper Club) */}
             {!isLoading && restaurants.length > 0 && (
                 <FlatList
-                    data={restaurants.slice(1)}
+                    data={rowRestaurants}
                     keyExtractor={(item) => item.id}
                     ListHeaderComponent={
                         <>
@@ -401,13 +413,14 @@ export const SearchScreen: React.FC = () => {
                                 </Text>
                             </View>
                             <RestaurantTopPick
-                                restaurant={restaurants[0]}
-                                onPress={() => handleRestaurantPress(restaurants[0])}
-                                onFavoriteToggle={() => handleFavoriteToggle(restaurants[0].id)}
-                                onDirections={() => handleDirections(restaurants[0])}
+                                restaurant={heroRestaurant}
+                                badgeLabel={heroIsWheelPick ? undefined : 'Top result'}
+                                onPress={() => handleRestaurantPress(heroRestaurant)}
+                                onFavoriteToggle={() => handleFavoriteToggle(heroRestaurant.id)}
+                                onDirections={() => handleDirections(heroRestaurant)}
                                 onSpinAgain={handleSpinAgain}
                             />
-                            {restaurants.length > 1 && (
+                            {rowRestaurants.length > 0 && (
                                 <Text style={styles.subhead}>More nearby</Text>
                             )}
                         </>


### PR DESCRIPTION
Fixes #48.

## Problem
The results-list hero was `restaurants[0]` and always badged **'🎰 The wheel picked'** — so after spinning result A, 'View All' showed the badge on the wrong restaurant.

## Fix (Option A)
- Hero is driven by the actual spin winner: `state.spinHistory[0].restaurant`.
- Prefer the winner from the current filtered list (keeps favorite/block state); surface it even if active filters would hide it.
- **No spin this session** → fall back to the top result with a neutral **'Top result'** badge — never falsely claim a pick.
- Rows exclude the hero (no duplication).

## Tests
- Winner that isn't first (B) becomes the 'wheel picked' hero; A is a plain row.
- No spin → no 'wheel picked' badge; hero shows 'Top result'.
- Full suite: 40 suites / 370 tests green.