### PR TITLE
test: de-flake logging perf test (drop wall-clock assertions)

### DIFF
--- a/__tests__/guardrails/unsafeLogging.test.ts
+++ b/__tests__/guardrails/unsafeLogging.test.ts
@@ -294,26 +294,17 @@ describe('Performance Impact Assessment', () => {
       filters: { categoryIds: ['restaurants'], openNow: true },
     };
 
-    // Measure clipping performance
-    const clipStart = performance.now();
+    // clip + logSafe must run without error on large data. Wall-clock timing
+    // assertions were removed: absolute ms thresholds measure the (shared, noisy)
+    // CI runner, not the code, and flaked intermittently. The real guarantee —
+    // that clipping bounds the payload size — is asserted deterministically below.
     const clipped = clip(testData, { maxItems: 5 });
-    const clipDuration = performance.now() - clipStart;
-
-    // Should complete quickly (< 10ms for reasonable data sizes)
-    expect(clipDuration).toBeLessThan(10);
-
-    // Measure full logSafe performance
-    const logStart = performance.now();
     logSafe('performance-test', testData);
-    const logDuration = performance.now() - logStart;
-
-    // Should complete very quickly (< 5ms)
-    expect(logDuration).toBeLessThan(5);
 
     // Clipped data should be much smaller
     const originalSize = JSON.stringify(testData).length;
     const clippedSize = JSON.stringify(clipped).length;
-    
+
     expect(clippedSize).toBeLessThan(originalSize * 0.2); // < 20% of original
   });
 });


### PR DESCRIPTION
The `unsafeLogging` 'minimal performance impact' test asserts absolute wall-clock thresholds (`clip < 10ms`, `logSafe < 5ms`). Those measure the **shared CI runner**, not the code — it flaked on PR #51 (`7ms > 5ms`) and will intermittently block any PR.

Drop the two timing assertions; keep the deterministic guarantee (clipping bounds the payload to < 20% of original) and still call `clip` + `logSafe` so a crash still fails the test.