### PR TITLE
feat(filters): distance slider (0.5–25 mi)

### DIFF
--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -45,6 +45,17 @@ jest.mock('expo-linear-gradient', () => {
   };
 });
 
+// Mock @react-native-community/slider (native module) as a plain View that
+// forwards props (testID, onValueChange) so tests can fire value changes.
+jest.mock('@react-native-community/slider', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: (props) => React.createElement(View, props),
+  };
+});
+
 // Mock expo-location to prevent native module errors
 jest.mock('expo-location', () => ({
   requestForegroundPermissionsAsync: jest.fn(() => Promise.resolve({ status: 'granted' })),

--- a/components/filter/FiltersSheet.tsx
+++ b/components/filter/FiltersSheet.tsx
@@ -10,6 +10,7 @@ import {
   Switch,
 } from 'react-native';
 import { MaterialIcons as Icon } from '@expo/vector-icons';
+import Slider from '@react-native-community/slider';
 import Config from '../../Config';
 import { RootContext } from '../../context/RootContext';
 import { setFilters, resetFilters } from '../../context/reducer';
@@ -18,10 +19,15 @@ import { supperClub } from '../../theme/supperClub';
 import { Text } from '../Themed';
 import Divider from '../shared/Divider';
 import { Filters } from '../../context/state';
-import { DISTANCE_OPTIONS, getDistanceLabel } from '../../utils/filterBusinesses';
+import { getDistanceLabel } from '../../utils/filterBusinesses';
 
 // Number of categories to show initially
 const INITIAL_CATEGORY_COUNT = 12;
+
+// Distance slider bounds (meters). Yelp caps its search radius at 40,000 m (~25 mi).
+const MIN_RADIUS_METERS = 804;    // 0.5 mi
+const MAX_RADIUS_METERS = 40000;  // ~25 mi (Yelp maximum)
+const RADIUS_STEP_METERS = 804;   // ~0.5 mi increments
 
 interface FiltersSheetProps {
   visible: boolean;
@@ -54,6 +60,12 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
 
   const updateLocalFilters = (updates: Partial<Filters>) => {
     setLocalFilters(prev => ({ ...prev, ...updates }));
+  };
+
+  // Distance handler — clamp defensively to the Yelp-supported range.
+  const handleRadiusChange = (value: number) => {
+    const clamped = Math.min(MAX_RADIUS_METERS, Math.max(MIN_RADIUS_METERS, value));
+    updateLocalFilters({ radiusMeters: Math.round(clamped) });
   };
 
   // Price level handlers
@@ -324,25 +336,24 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
               </Text>
             </View>
             <View style={styles.distanceContainer}>
-              {DISTANCE_OPTIONS.map(option => (
-                <Pressable
-                  key={option.meters}
-                  onPress={() => updateLocalFilters({ radiusMeters: option.meters })}
-                  style={({ pressed }) => [
-                    styles.distanceOption,
-                    localFilters.radiusMeters === option.meters && styles.distanceOptionSelected,
-                    { opacity: !Config.isAndroid && pressed ? 0.6 : 1 }
-                  ]}
-                  android_ripple={{ color: 'lightgrey' }}
-                >
-                  <Text style={[
-                    styles.distanceOptionText,
-                    localFilters.radiusMeters === option.meters && styles.distanceOptionTextSelected
-                  ]}>
-                    {option.label}
-                  </Text>
-                </Pressable>
-              ))}
+              <Slider
+                testID="distance-slider"
+                style={styles.distanceSlider}
+                minimumValue={MIN_RADIUS_METERS}
+                maximumValue={MAX_RADIUS_METERS}
+                step={RADIUS_STEP_METERS}
+                value={localFilters.radiusMeters}
+                onValueChange={handleRadiusChange}
+                minimumTrackTintColor={supperClub.gold}
+                maximumTrackTintColor={supperClub.borderSoft}
+                thumbTintColor={supperClub.gold}
+                accessibilityLabel="Search distance"
+                accessibilityHint="Adjusts how far to search for restaurants"
+              />
+              <View style={styles.distanceScaleRow}>
+                <Text style={styles.distanceScaleLabel}>0.5 mi</Text>
+                <Text style={styles.distanceScaleLabel}>25 mi</Text>
+              </View>
             </View>
           </View>
 
@@ -572,31 +583,23 @@ const styles = StyleSheet.create({
     marginRight: 16,
   },
   distanceContainer: {
-    flexDirection: 'row',
     paddingHorizontal: 16,
     paddingBottom: 16,
   },
-  distanceOption: {
-    flex: 1,
-    borderColor: supperClub.borderSoft,
-    borderWidth: 1,
-    borderRadius: 8,
-    paddingVertical: 8,
-    marginHorizontal: 2,
-    backgroundColor: 'rgba(255, 255, 255, 0.05)',
+  distanceSlider: {
+    width: '100%',
+    height: 44,
   },
-  distanceOptionSelected: {
-    backgroundColor: supperClub.primary,
-    borderColor: supperClub.primary,
+  distanceScaleRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    paddingHorizontal: 4,
+    marginTop: 2,
   },
-  distanceOptionText: {
-    textAlign: 'center',
-    fontSize: 14,
+  distanceScaleLabel: {
+    fontSize: 12,
     fontFamily: AppStyles.fonts.regular,
-    color: supperClub.text,
-  },
-  distanceOptionTextSelected: {
-    color: '#FFFFFF',
+    color: supperClub.textMuted,
   },
   ratingContainer: {
     flexDirection: 'row',

--- a/components/filter/__tests__/FiltersSheet.test.tsx
+++ b/components/filter/__tests__/FiltersSheet.test.tsx
@@ -191,15 +191,49 @@ describe('FiltersSheet', () => {
   });
 
   describe('Distance Filter', () => {
-    it('should display distance options', () => {
-      const { getAllByText } = renderFiltersSheet();
-      
+    it('should render a distance slider with scale labels', () => {
+      const { getByTestId, getAllByText } = renderFiltersSheet();
+
       expect(getAllByText('Distance')[0]).toBeTruthy();
+      expect(getByTestId('distance-slider')).toBeTruthy();
+      // Scale endpoints for orientation
       expect(getAllByText('0.5 mi').length).toBeGreaterThan(0);
-      expect(getAllByText('1 mi').length).toBeGreaterThan(0);
-      expect(getAllByText('2 mi')[0]).toBeTruthy();
-      expect(getAllByText('5 mi')[0]).toBeTruthy();
-      expect(getAllByText('10 mi')[0]).toBeTruthy();
+      expect(getAllByText('25 mi').length).toBeGreaterThan(0);
+    });
+
+    it('updates the distance label as the slider moves', () => {
+      const { getByTestId, getAllByText } = renderFiltersSheet();
+
+      // 24000 m ≈ 14.9 mi
+      fireEvent(getByTestId('distance-slider'), 'valueChange', 24000);
+
+      expect(getAllByText('14.9 mi').length).toBeGreaterThan(0);
+    });
+
+    it('applies the slider distance on Apply Filters', () => {
+      const { getByTestId, getByText, mockDispatch } = renderFiltersSheet();
+
+      fireEvent(getByTestId('distance-slider'), 'valueChange', 12070); // ~7.5 mi
+      fireEvent.press(getByText('Apply Filters'));
+
+      expect(mockDispatch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: { filters: expect.objectContaining({ radiusMeters: 12070 }) },
+        })
+      );
+    });
+
+    it('clamps distance to the Yelp maximum (40000 m)', () => {
+      const { getByTestId, getByText, mockDispatch } = renderFiltersSheet();
+
+      fireEvent(getByTestId('distance-slider'), 'valueChange', 99999);
+      fireEvent.press(getByText('Apply Filters'));
+
+      const applyCall = mockDispatch.mock.calls.find(
+        (c: any[]) => c[0]?.payload?.filters?.radiusMeters !== undefined
+      );
+      expect(applyCall).toBeTruthy();
+      expect(applyCall![0].payload.filters.radiusMeters).toBeLessThanOrEqual(40000);
     });
 
     it('should show current distance selection', () => {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@miblanchard/react-native-slider": "^2.1.0",
     "@ptomasroos/react-native-multi-slider": "^2.2.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@react-native-community/slider": "5.0.1",
     "@react-navigation/bottom-tabs": "^7.0.0",
     "@react-navigation/material-bottom-tabs": "^6.2.4",
     "@react-navigation/material-top-tabs": "^7.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1536,6 +1536,11 @@
   dependencies:
     merge-options "^3.0.4"
 
+"@react-native-community/slider@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/slider/-/slider-5.0.1.tgz#478789e526af31e0660c6f49fa5c5429d8d4287b"
+  integrity sha512-K3JRWkIW4wQ79YJ6+BPZzp1SamoikxfPRw7Yw4B4PElEQmqZFrmH9M5LxvIo460/3QSrZF/wCgi3qizJt7g/iw==
+
 "@react-native/assets-registry@0.81.5":
   version "0.81.5"
   resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.81.5.tgz#d22c924fa6f6d4a463c5af34ce91f38756c0fa7d"


### PR DESCRIPTION
## Summary
Closes #49. Replaces the five discrete distance preset buttons (0.5–10 mi) with a horizontal slider spanning **0.5–25 mi** (804–40,000 m — Yelp's radius cap), stepping in ~0.5 mi increments. The live value shows in the section subtitle; `0.5 mi` / `25 mi` scale labels anchor the ends.

## Why
The presets topped out at 10 mi and offered no in-between values, capping users well short of what Yelp supports. A slider gives full continuous control up to the API maximum.

## Changes
- **`@react-native-community/slider`** (SDK-pinned `5.0.1`) + a jest mock in `__tests__/setup.js` (same View-wrapper pattern as `react-native-svg` / `expo-linear-gradient`).
- Defensive clamp to `[804, 40000]` m in the change handler — an out-of-range value can never reach the Yelp query.
- **Supper Club** styling: gold active track + thumb, `borderSoft` inactive track, muted cream scale labels; 44px slider height for touch target, with a11y label/hint.
- Reuses `getDistanceLabel()` for the live readout (already handles arbitrary meters). Drops the now-unused `DISTANCE_OPTIONS` import and preset styles.

## Testing
- TDD: RED (4 new distance tests) → GREEN. Covers: slider + scale labels render, label updates on move (24000 m → "14.9 mi"), value applies via Apply Filters, and clamps to the 40,000 m Yelp max.
- Full suite: **40 suites / 374 tests green**. `tsc` error count unchanged (161 pre-existing baseline; zero new).

## Notes
- Needs a **native rebuild** (`eas build` / `expo run:ios`) to render on device — same as the other native deps.
- The legacy `SliderView → DistanceFilter → FilterModal` chain remains unrouted and untouched; `FiltersSheet` is the live filter UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)