### PR TITLE
feat(search): wire distance radius into Yelp request + cache (#55)

### DIFF
--- a/__tests__/hooks/useResults.radius.test.ts
+++ b/__tests__/hooks/useResults.radius.test.ts
@@ -61,6 +61,22 @@ describe('useResults radius wiring (#55)', () => {
     );
   });
 
+  it('sends radius on the location-string path too (no coords)', async () => {
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('pizza', 'Columbus', null, 8047);
+    });
+    expect(mockedGet).toHaveBeenCalledWith(
+      '/businesses/search',
+      expect.objectContaining({
+        params: expect.objectContaining({ location: 'Columbus', radius: 8047 }),
+      })
+    );
+    // And it did NOT fall back to the coordinate branch.
+    const call = mockedGet.mock.calls[0];
+    expect(call[1].params.latitude).toBeUndefined();
+  });
+
   it('clamps radius to the Yelp maximum of 40000 m', async () => {
     const { result } = renderHook(() => useResults());
     await act(async () => {

--- a/__tests__/hooks/useResults.radius.test.ts
+++ b/__tests__/hooks/useResults.radius.test.ts
@@ -1,0 +1,91 @@
+/**
+ * #55 — the distance slider's radiusMeters must reach the Yelp request, not
+ * just the client-side filter. These tests exercise the REAL hooks (not a
+ * reconstruction) so a regression to a hardcoded radius fails here.
+ */
+import { renderHook, act } from '@testing-library/react-native';
+import useResults from '../../hooks/useResults';
+import useResultsPersistence from '../../hooks/useResultsPersistence';
+import yelp from '../../api/yelp';
+
+// Mock the Yelp axios client so we can assert the request params.
+jest.mock('../../api/yelp', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+
+// Cache-miss storage so searchApi always reaches the network path.
+const mockStorage = {
+  getItem: jest.fn(async () => null),
+  setItem: jest.fn(async () => {}),
+  getAllItems: jest.fn(() => []),
+};
+jest.mock('../../hooks/usePersistentStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockStorage),
+}));
+
+const mockedGet = yelp.get as jest.Mock;
+const coords = { latitude: 39.9612, longitude: -82.9988 } as any;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorage.getItem.mockResolvedValue(null);
+  mockedGet.mockResolvedValue({ status: 200, data: { businesses: [] } });
+});
+
+describe('useResults radius wiring (#55)', () => {
+  it('sends the requested radiusMeters as the Yelp radius param', async () => {
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('pizza', 'Columbus', coords, 8047);
+    });
+    expect(mockedGet).toHaveBeenCalledWith(
+      '/businesses/search',
+      expect.objectContaining({
+        params: expect.objectContaining({ radius: 8047, latitude: coords.latitude }),
+      })
+    );
+  });
+
+  it('defaults to 1600 m when no radius is provided (back-compat)', async () => {
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('pizza', 'Columbus', coords);
+    });
+    expect(mockedGet).toHaveBeenCalledWith(
+      '/businesses/search',
+      expect.objectContaining({
+        params: expect.objectContaining({ radius: 1600 }),
+      })
+    );
+  });
+
+  it('clamps radius to the Yelp maximum of 40000 m', async () => {
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('pizza', 'Columbus', coords, 99999);
+    });
+    const call = mockedGet.mock.calls.find(
+      (c: any[]) => c[1]?.params?.radius !== undefined
+    );
+    expect(call).toBeTruthy();
+    expect(call![1].params.radius).toBeLessThanOrEqual(40000);
+  });
+});
+
+describe('generateCacheKey radius (#55)', () => {
+  it('varies the cache key by radius so radii do not collide', () => {
+    const { result } = renderHook(() => useResultsPersistence());
+    const k1 = result.current.generateCacheKey('Columbus', 'pizza', coords, 1600);
+    const k2 = result.current.generateCacheKey('Columbus', 'pizza', coords, 8047);
+    expect(k1).not.toBe(k2);
+  });
+
+  it('is stable for the same radius', () => {
+    const { result } = renderHook(() => useResultsPersistence());
+    const k1 = result.current.generateCacheKey('Columbus', 'pizza', coords, 8047);
+    const k2 = result.current.generateCacheKey('Columbus', 'pizza', coords, 8047);
+    expect(k1).toBe(k2);
+  });
+});

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, within } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, within } from '@testing-library/react-native';
 import { SearchScreen } from '../../screens/SearchScreen';
 import { RootContext } from '../../context/RootContext';
 import { mockInitialState } from '../mocks/mockState';
@@ -12,9 +12,13 @@ jest.mock('@react-navigation/native', () => ({
 
 // Data hooks. SearchScreen destructures 5 values from useResults and 10 from
 // useLocation; return correctly-shaped tuples so nothing resolves to undefined.
+// Stable spies (prefixed `mock` so the jest.mock factory may reference them)
+// let us assert searchApi calls across re-renders (#55 re-search on radius).
+const mockSearchApi = jest.fn(async () => []);
+const mockSearchApiWithResolver = jest.fn(async () => []);
 jest.mock('../../hooks/useResults', () => ({
   __esModule: true,
-  default: () => ['', { id: '', businesses: [] }, jest.fn(), jest.fn(), false],
+  default: () => ['', { id: '', businesses: [] }, mockSearchApi, mockSearchApiWithResolver, false],
   INIT_RESULTS: { id: '', businesses: [] },
 }));
 
@@ -180,5 +184,56 @@ describe('SearchScreen', () => {
     expect(queryByText(/The wheel picked/)).toBeNull();
     expect(getByText('Top result')).toBeTruthy();
     expect(within(getByTestId('restaurant-card-a')).getByText(/Spin again/)).toBeTruthy();
+  });
+
+  it('re-fetches with the new radius when the distance filter changes (#55)', async () => {
+    const { getByPlaceholderText, rerender } = render(
+      <RootContext.Provider value={{ state: mockInitialState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    // Commit a search term (no coords/resolver in the mocks → searchApi path).
+    fireEvent.changeText(getByPlaceholderText('What are you craving?'), 'pizza');
+    mockSearchApi.mockClear();
+
+    // User applies a larger distance in the filter sheet.
+    const newState = {
+      ...mockInitialState,
+      filters: { ...mockInitialState.filters, radiusMeters: 8047 },
+    };
+    rerender(
+      <RootContext.Provider value={{ state: newState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+
+    await waitFor(() => {
+      expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 8047);
+    });
+  });
+
+  it('does not re-fetch on a radius change when there is no active term (#55)', async () => {
+    const { rerender } = render(
+      <RootContext.Provider value={{ state: mockInitialState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    mockSearchApi.mockClear();
+    mockSearchApiWithResolver.mockClear();
+
+    const newState = {
+      ...mockInitialState,
+      filters: { ...mockInitialState.filters, radiusMeters: 8047 },
+    };
+    rerender(
+      <RootContext.Provider value={{ state: newState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+
+    // Give any effect a tick to (not) fire.
+    await waitFor(() => expect(mockDispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'unused' })));
+    expect(mockSearchApi).not.toHaveBeenCalled();
+    expect(mockSearchApiWithResolver).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -253,6 +253,38 @@ describe('SearchScreen', () => {
     });
   });
 
+  it('replays the submitted term on a radius refetch, not the draft input (#55)', async () => {
+    const { getByPlaceholderText, rerender } = render(
+      <RootContext.Provider value={{ state: mockInitialState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    const input = getByPlaceholderText('What are you craving?');
+    // Submit "pizza"...
+    fireEvent.changeText(input, 'pizza');
+    fireEvent(input, 'submitEditing');
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 1600));
+    // ...then edit the box to an UNsubmitted draft.
+    fireEvent.changeText(input, 'sushi');
+    mockSearchApi.mockClear();
+
+    // Radius change: the refetch must use the submitted "pizza", not "sushi".
+    const newState = {
+      ...mockInitialState,
+      filters: { ...mockInitialState.filters, radiusMeters: 8047 },
+    };
+    rerender(
+      <RootContext.Provider value={{ state: newState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 8047)
+    );
+    expect(mockSearchApi).not.toHaveBeenCalledWith('sushi', expect.anything(), null, 8047);
+  });
+
   it('does not re-fetch on a radius change when there is no active term (#55)', async () => {
     const { rerender } = render(
       <RootContext.Provider value={{ state: mockInitialState, dispatch: mockDispatch }}>

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, within } from '@testing-library/react-native';
+import { render, fireEvent, waitFor, within, act } from '@testing-library/react-native';
 import { SearchScreen } from '../../screens/SearchScreen';
 import { RootContext } from '../../context/RootContext';
 import { mockInitialState } from '../mocks/mockState';
@@ -192,8 +192,12 @@ describe('SearchScreen', () => {
         <SearchScreen />
       </RootContext.Provider>
     );
-    // Commit a search term (no coords/resolver in the mocks → searchApi path).
-    fireEvent.changeText(getByPlaceholderText('What are you craving?'), 'pizza');
+    // Perform a real search first (no coords/resolver in the mocks → searchApi
+    // path). This records the radius the results were fetched with.
+    const input = getByPlaceholderText('What are you craving?');
+    fireEvent.changeText(input, 'pizza');
+    fireEvent(input, 'submitEditing');
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 1600));
     mockSearchApi.mockClear();
 
     // User applies a larger distance in the filter sheet.
@@ -207,6 +211,43 @@ describe('SearchScreen', () => {
       </RootContext.Provider>
     );
 
+    await waitFor(() => {
+      expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 8047);
+    });
+  });
+
+  it('does not drop a radius change applied during an in-flight search (#55)', async () => {
+    // Hold the first search open so isSearching stays true when radius changes.
+    let releaseFirstSearch: (v: any) => void = () => {};
+    mockSearchApi.mockImplementationOnce(
+      () => new Promise((resolve) => { releaseFirstSearch = resolve; })
+    );
+
+    const { getByPlaceholderText, rerender } = render(
+      <RootContext.Provider value={{ state: mockInitialState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    const input = getByPlaceholderText('What are you craving?');
+    fireEvent.changeText(input, 'pizza');
+    fireEvent(input, 'submitEditing');
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 1600));
+
+    // Radius changes WHILE the first search is still in flight.
+    const newState = {
+      ...mockInitialState,
+      filters: { ...mockInitialState.filters, radiusMeters: 8047 },
+    };
+    rerender(
+      <RootContext.Provider value={{ state: newState, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    // No refetch yet — still busy.
+    expect(mockSearchApi).not.toHaveBeenCalledWith('pizza', expect.anything(), null, 8047);
+
+    // Complete the in-flight search; the deferred radius change must now refetch.
+    await act(async () => { releaseFirstSearch([]); });
     await waitFor(() => {
       expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 8047);
     });

--- a/hooks/useResults.ts
+++ b/hooks/useResults.ts
@@ -11,6 +11,14 @@ import { hasBlockedCategory } from "../constants/foodCategories";
 
 export const PRICE_OPTIONS = [`$`, `$$`, `$$$`, `$$$$`];
 
+// Yelp caps its search radius at 40,000 m (~25 mi). The distance slider clamps
+// too, but this is the API boundary so we guard here as well (#55).
+const YELP_MAX_RADIUS_METERS = 40000;
+const DEFAULT_RADIUS_METERS = 1600; // ~1 mile
+
+const clampRadius = (radiusMeters: number): number =>
+	Math.min(YELP_MAX_RADIUS_METERS, Math.max(1, Math.round(radiusMeters)));
+
 export interface ResultsProps {
 	id: string;
 	businesses: BusinessProps[];
@@ -87,17 +95,19 @@ export default function useResults() {
 	};
 
 	const searchApi = useCallback(async (
-		searchTerm: string, 
-		location = `columbus`, 
-		coords: LocationObjectCoords | null = null
+		searchTerm: string,
+		location = `columbus`,
+		coords: LocationObjectCoords | null = null,
+		radiusMeters: number = DEFAULT_RADIUS_METERS
 	): Promise<BusinessProps[]> => {
 		setIsLoading(true);
+		const radius = clampRadius(radiusMeters);
 		try {
 			devLog('Starting search:', { searchTerm, location, coords: coords ? `${coords.latitude},${coords.longitude}` : 'none' });
 			setErrorMessage('');
 			
 			// First, try to get cached results
-			const cachedResults = await resultsPersistence.getCachedResults(location, searchTerm, coords);
+			const cachedResults = await resultsPersistence.getCachedResults(location, searchTerm, coords, radius);
 			if (cachedResults) {
 				const businesses = Array.isArray(cachedResults) ? cachedResults : [];
 				const cachedResultsObj: ResultsProps = {
@@ -123,7 +133,7 @@ export default function useResults() {
 				// Use coordinates for more accurate search
 				searchParams.latitude = coords.latitude;
 				searchParams.longitude = coords.longitude;
-				searchParams.radius = 1600; // ~1 mile in meters
+				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
 				devLog('Using coordinates for search:', coords);
 			} else if (location.trim() !== '') {
 				// Fallback to location string
@@ -173,7 +183,7 @@ export default function useResults() {
 				};
 
 				// Cache the results (this is debounced and change-detected automatically)
-				await resultsPersistence.cacheResults(location, searchTerm, filteredBusinesses, coords);
+				await resultsPersistence.cacheResults(location, searchTerm, filteredBusinesses, coords, radius);
 
 				setResults(finalResults);
 				return filteredBusinesses;
@@ -216,9 +226,11 @@ export default function useResults() {
 	 */
 	const searchApiWithResolver = useCallback(async (
 		searchTerm: string,
-		resolvedLocation: ResolvedLocation
+		resolvedLocation: ResolvedLocation,
+		radiusMeters: number = DEFAULT_RADIUS_METERS
 	): Promise<BusinessProps[]> => {
 		setIsLoading(true);
+		const radius = clampRadius(radiusMeters);
 		try {
 			devLog('Enhanced search starting:', { 
 				searchTerm, 
@@ -230,9 +242,10 @@ export default function useResults() {
 
 			// Generate versioned cache key to avoid corrupted entries
 			const cacheKey = resultsPersistence.generateCacheKey(
-				resolvedLocation.label, 
-				searchTerm, 
-				resolvedLocation.coords
+				resolvedLocation.label,
+				searchTerm,
+				resolvedLocation.coords,
+				radius
 			);
 
 			devLog('Using cache key:', cacheKey);
@@ -264,7 +277,7 @@ export default function useResults() {
 				// PREFERRED: Use coordinates for most accurate search
 				searchParams.latitude = resolvedLocation.coords.latitude;
 				searchParams.longitude = resolvedLocation.coords.longitude;
-				searchParams.radius = 1600; // ~1 mile in meters
+				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
 				devLog('Using coordinates for Yelp search:', resolvedLocation.coords);
 			} else if (resolvedLocation.label) {
 				// FALLBACK: Use canonical location string (e.g., "Powell, OH")

--- a/hooks/useResults.ts
+++ b/hooks/useResults.ts
@@ -136,8 +136,10 @@ export default function useResults() {
 				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
 				devLog('Using coordinates for search:', coords);
 			} else if (location.trim() !== '') {
-				// Fallback to location string
+				// Fallback to location string. Yelp supports `radius` with
+				// `location`, so the slider applies on this path too (#55).
 				searchParams.location = location;
+				searchParams.radius = radius;
 				devLog('Using location string for search:', location);
 			} else {
 				devLog('Invalid search parameters');
@@ -280,8 +282,10 @@ export default function useResults() {
 				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
 				devLog('Using coordinates for Yelp search:', resolvedLocation.coords);
 			} else if (resolvedLocation.label) {
-				// FALLBACK: Use canonical location string (e.g., "Powell, OH")
+				// FALLBACK: Use canonical location string (e.g., "Powell, OH").
+				// Yelp supports `radius` with `location`, so apply it here too (#55).
 				searchParams.location = resolvedLocation.label;
+				searchParams.radius = radius;
 				devLog('Using canonical location string for Yelp search:', resolvedLocation.label);
 			} else {
 				devLog('No valid search location available');

--- a/hooks/useResultsPersistence.ts
+++ b/hooks/useResultsPersistence.ts
@@ -41,30 +41,35 @@ export default function useResultsPersistence() {
   /**
    * Generate a versioned cache key from search parameters
    */
-  const generateCacheKey = useCallback((location: string, term: string, coords?: any): string => {
+  const generateCacheKey = useCallback((location: string, term: string, coords?: any, radiusMeters?: number): string => {
     const normalizedTerm = term.trim().toLowerCase();
-    
+    // Radius is part of the cache identity: a 1-mile fetch must not satisfy a
+    // 25-mile request (#55). Omitted when undefined so callers that don't pass
+    // a radius keep their legacy keys.
+    const radiusSuffix = radiusMeters != null ? `:r${Math.round(radiusMeters)}` : '';
+
     if (coords?.latitude && coords?.longitude) {
       // Use coordinates for more precise caching
       const lat = coords.latitude.toFixed(4);
       const lng = coords.longitude.toFixed(4);
-      return `${CACHE_VERSION}:search:${lat},${lng}:${normalizedTerm}`;
+      return `${CACHE_VERSION}:search:${lat},${lng}:${normalizedTerm}${radiusSuffix}`;
     }
-    
+
     // Fallback to location string
     const normalizedLocation = location.trim().toLowerCase();
-    return `${CACHE_VERSION}:search:${normalizedLocation}:${normalizedTerm}`;
+    return `${CACHE_VERSION}:search:${normalizedLocation}:${normalizedTerm}${radiusSuffix}`;
   }, []);
 
   /**
    * Load cached results for a search with corruption detection
    */
   const getCachedResults = useCallback(async (
-    location: string, 
-    term: string, 
-    coords?: any
+    location: string,
+    term: string,
+    coords?: any,
+    radiusMeters?: number
   ): Promise<BusinessProps[] | null> => {
-    const cacheKey = generateCacheKey(location, term, coords);
+    const cacheKey = generateCacheKey(location, term, coords, radiusMeters);
     
     try {
       const cached = await storage.getItem<BusinessProps[]>(cacheKey);
@@ -95,9 +100,10 @@ export default function useResultsPersistence() {
     location: string,
     term: string,
     results: BusinessProps[],
-    coords?: any
+    coords?: any,
+    radiusMeters?: number
   ): Promise<void> => {
-    const cacheKey = generateCacheKey(location, term, coords);
+    const cacheKey = generateCacheKey(location, term, coords, radiusMeters);
     
     // Prevent duplicate cache operations for the same key
     if (activeCacheKeys.current.has(cacheKey)) {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -118,6 +118,9 @@ export const HomeScreen: React.FC = () => {
     });
   });
 
+  // Radius the current results were fetched with (null until the first search).
+  const lastFetchedRadiusRef = useRef<number | null>(null);
+
   const handleSpin = () => {
     // If no results yet but have valid query, trigger search first
     if (!hasResults && hasValidSearchQuery) {
@@ -127,6 +130,18 @@ export const HomeScreen: React.FC = () => {
 
     if (!hasResults) {
       setErrorMessage('Please enter a search term first');
+      return;
+    }
+
+    // Radius changed since the current results were fetched (e.g. the user
+    // widened Distance in the filter sheet). Yelp returns a different set for a
+    // new radius, so re-search before spinning instead of spinning the stale,
+    // narrower result set (#55). The refetch auto-spins on completion.
+    if (
+      lastFetchedRadiusRef.current !== null &&
+      lastFetchedRadiusRef.current !== state.filters.radiusMeters
+    ) {
+      handleSearch();
       return;
     }
 
@@ -141,6 +156,7 @@ export const HomeScreen: React.FC = () => {
     const term = searchQuery.trim();
     if (!term) return;
 
+    lastFetchedRadiusRef.current = state.filters.radiusMeters;
     setIsSearching(true);
     setErrorMessage('');
     try {

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -148,9 +148,9 @@ export const HomeScreen: React.FC = () => {
       const resolvedLocation = await resolveSearchArea(state.location || canonicalLocation);
 
       if (resolvedLocation) {
-        businesses = await searchApiWithResolver(term, resolvedLocation);
+        businesses = await searchApiWithResolver(term, resolvedLocation, state.filters.radiusMeters);
       } else {
-        businesses = await searchApi(term, state.location || 'Current Location', coords);
+        businesses = await searchApi(term, state.location || 'Current Location', coords, state.filters.radiusMeters);
       }
 
       // Filter out blocked restaurants

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -159,10 +159,15 @@ export const SearchScreen: React.FC = () => {
         }
     }, [state.results]);
 
+    // Radius the currently-displayed results were fetched with (null until the
+    // first search). Drives the refetch-on-radius-change effect below (#55).
+    const lastFetchedRadiusRef = useRef<number | null>(null);
+
     const handleSearch = async () => {
         const term = searchQuery.trim();
         if (!term) return;
 
+        lastFetchedRadiusRef.current = state.filters.radiusMeters;
         setIsSearching(true);
         setErrorMessage('');
         try {
@@ -188,22 +193,26 @@ export const SearchScreen: React.FC = () => {
         }
     };
 
-    // Re-fetch when the search radius changes (e.g. the user applies a larger
-    // distance in the filter sheet). Radius changes WHAT Yelp returns, so a
-    // client-side re-filter can't surface farther restaurants — we must refetch
-    // (#55). Other filters (price/category/rating) stay client-side.
-    const prevRadiusRef = useRef(state.filters.radiusMeters);
+    // Re-fetch when the applied radius no longer matches what the displayed
+    // results were fetched with (e.g. the user applies a larger distance in the
+    // filter sheet). Radius changes WHAT Yelp returns, so a client-side
+    // re-filter can't surface farther restaurants — we must refetch (#55). Other
+    // filters (price/category/rating) stay client-side.
+    //
+    // Keyed on `isSearching` too: if the radius changes mid-flight we skip while
+    // busy, then this re-runs when the in-flight search settles so the change is
+    // never dropped. Comparing against the last *fetched* radius (not the last
+    // seen value) makes that reconciliation self-correcting and loop-free —
+    // handleSearch resets the ref to the radius it fetched.
     useEffect(() => {
-        const nextRadius = state.filters.radiusMeters;
-        if (prevRadiusRef.current === nextRadius) return;
-        prevRadiusRef.current = nextRadius;
-        if (searchQuery.trim() && !isSearching) {
-            handleSearch();
-        }
-        // Intentionally keyed only on radiusMeters; handleSearch reads the
-        // current term/coords via closure at fire time.
+        if (isSearching) return;                 // wait for any in-flight search
+        if (!searchQuery.trim()) return;         // nothing to search
+        if (lastFetchedRadiusRef.current === null) return; // no search performed yet
+        if (lastFetchedRadiusRef.current === state.filters.radiusMeters) return; // already current
+        handleSearch();
+        // handleSearch reads the current term/coords via closure at fire time.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [state.filters.radiusMeters]);
+    }, [state.filters.radiusMeters, isSearching]);
 
     const handleFiltersPress = () => {
         dispatch(setShowFilter(true));

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -159,14 +159,18 @@ export const SearchScreen: React.FC = () => {
         }
     }, [state.results]);
 
-    // Radius the currently-displayed results were fetched with (null until the
-    // first search). Drives the refetch-on-radius-change effect below (#55).
+    // The last *submitted* term and the radius its results were fetched with
+    // (both empty/null until the first search). The radius-refetch effect below
+    // replays the submitted term — never the current draft input — so editing
+    // the box without submitting can't hijack a refetch (#55).
+    const lastSubmittedTermRef = useRef<string>('');
     const lastFetchedRadiusRef = useRef<number | null>(null);
 
-    const handleSearch = async () => {
-        const term = searchQuery.trim();
+    const handleSearch = async (termOverride?: string) => {
+        const term = (termOverride ?? searchQuery).trim();
         if (!term) return;
 
+        lastSubmittedTermRef.current = term;
         lastFetchedRadiusRef.current = state.filters.radiusMeters;
         setIsSearching(true);
         setErrorMessage('');
@@ -205,12 +209,11 @@ export const SearchScreen: React.FC = () => {
     // seen value) makes that reconciliation self-correcting and loop-free —
     // handleSearch resets the ref to the radius it fetched.
     useEffect(() => {
-        if (isSearching) return;                 // wait for any in-flight search
-        if (!searchQuery.trim()) return;         // nothing to search
-        if (lastFetchedRadiusRef.current === null) return; // no search performed yet
+        if (isSearching) return;                          // wait for any in-flight search
+        if (!lastSubmittedTermRef.current) return;        // no search submitted yet
         if (lastFetchedRadiusRef.current === state.filters.radiusMeters) return; // already current
-        handleSearch();
-        // handleSearch reads the current term/coords via closure at fire time.
+        handleSearch(lastSubmittedTermRef.current);       // replay the submitted term, not the draft
+        // handleSearch reads the current coords via closure at fire time.
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [state.filters.radiusMeters, isSearching]);
 
@@ -339,7 +342,7 @@ export const SearchScreen: React.FC = () => {
                         value={searchQuery}
                         onChangeText={setSearchQuery}
                         returnKeyType="search"
-                        onSubmitEditing={handleSearch}
+                        onSubmitEditing={() => handleSearch()}
                         editable={!isLoading}
                     />
                     {searchQuery.length > 0 && (

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -1,4 +1,4 @@
-import React, {useContext, useEffect, useState} from 'react';
+import React, {useContext, useEffect, useRef, useState} from 'react';
 import {ActivityIndicator, FlatList, Linking, Platform, Pressable, StyleSheet, Text, TextInput, View,} from 'react-native';
 import {SafeAreaView} from 'react-native-safe-area-context';
 import {Ionicons} from '@expo/vector-icons';
@@ -170,9 +170,9 @@ export const SearchScreen: React.FC = () => {
             const resolvedLocation = await resolveSearchArea(state.location || canonicalLocation);
 
             if (resolvedLocation) {
-                businesses = await searchApiWithResolver(term, resolvedLocation);
+                businesses = await searchApiWithResolver(term, resolvedLocation, state.filters.radiusMeters);
             } else {
-                businesses = await searchApi(term, state.location || 'Current Location', coords);
+                businesses = await searchApi(term, state.location || 'Current Location', coords, state.filters.radiusMeters);
             }
 
             // Filter out blocked restaurants
@@ -187,6 +187,23 @@ export const SearchScreen: React.FC = () => {
             setIsSearching(false);
         }
     };
+
+    // Re-fetch when the search radius changes (e.g. the user applies a larger
+    // distance in the filter sheet). Radius changes WHAT Yelp returns, so a
+    // client-side re-filter can't surface farther restaurants — we must refetch
+    // (#55). Other filters (price/category/rating) stay client-side.
+    const prevRadiusRef = useRef(state.filters.radiusMeters);
+    useEffect(() => {
+        const nextRadius = state.filters.radiusMeters;
+        if (prevRadiusRef.current === nextRadius) return;
+        prevRadiusRef.current = nextRadius;
+        if (searchQuery.trim() && !isSearching) {
+            handleSearch();
+        }
+        // Intentionally keyed only on radiusMeters; handleSearch reads the
+        // current term/coords via closure at fire time.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [state.filters.radiusMeters]);
 
     const handleFiltersPress = () => {
         dispatch(setShowFilter(true));

--- a/screens/__tests__/HomeScreen.radius-spin.test.tsx
+++ b/screens/__tests__/HomeScreen.radius-spin.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { HomeScreen } from '../HomeScreen';
+import { RootContext } from '../../context/RootContext';
+import { mockInitialState } from '../../__tests__/mocks/mockState';
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() }),
+}));
+
+// Stable spies (prefixed `mock` so the factory may reference them) let us assert
+// that "Spin Again" re-issues the Yelp search after a radius change (#55).
+const mockSearchApi = jest.fn(async () => []);
+const mockSearchApiWithResolver = jest.fn(async () => []);
+jest.mock('../../hooks/useResults', () => ({
+  __esModule: true,
+  default: () => ['', { id: '', businesses: [] }, mockSearchApi, mockSearchApiWithResolver, false],
+  INIT_RESULTS: { id: '', businesses: [] },
+}));
+
+jest.mock('../../hooks/useLocation', () => ({
+  __esModule: true,
+  default: () => ['', 'Columbus, OH', 'Columbus, OH', null, jest.fn(), jest.fn(), jest.fn(), false, jest.fn(), jest.fn()],
+}));
+
+jest.mock('../../hooks/useHistory', () => ({ useHistory: () => ({ addHistoryEntry: jest.fn() }) }));
+jest.mock('../../hooks/useBlocked', () => ({ useBlocked: () => ({ blocked: [] }) }));
+jest.mock('../../hooks/useCategories', () => ({ __esModule: true, default: () => ({ loadCategories: () => [] }) }));
+
+jest.mock('../../components/RouletteWheel', () => {
+  const { Pressable, Text } = require('react-native');
+  return {
+    RouletteWheel: ({ onSpin }: any) => (
+      <Pressable testID="roulette-wheel" onPress={onSpin}>
+        <Text>Wheel</Text>
+      </Pressable>
+    ),
+  };
+});
+jest.mock('../../components/ActiveFilterBar', () => {
+  const { View } = require('react-native');
+  return { ActiveFilterBar: () => <View testID="active-filter-bar" /> };
+});
+jest.mock('../../components/filter/FiltersSheet', () => {
+  const { View } = require('react-native');
+  return { __esModule: true, default: ({ visible }: any) => (visible ? <View testID="filters-sheet" /> : null) };
+});
+jest.mock('@expo/vector-icons', () => {
+  const { Text } = require('react-native');
+  const Icon = ({ name }: any) => <Text testID={`icon-${name}`}>{name}</Text>;
+  return { Ionicons: Icon, MaterialIcons: Icon, FontAwesome: Icon };
+});
+jest.mock('../../utils/filterBusinesses', () => ({
+  countActiveFilters: jest.fn(() => 0),
+  applyFilters: (results: any[]) => results,
+  DISTANCE_OPTIONS: [{ label: '1 mi', meters: 1600 }],
+  getDistanceLabel: jest.fn(() => '1 mi'),
+}));
+
+const mockDispatch = jest.fn();
+const withResults = (radiusMeters: number) => ({
+  ...mockInitialState,
+  results: [{ id: 'a', name: 'Alpha Cafe', categories: [] }] as any,
+  filters: { ...mockInitialState.filters, radiusMeters },
+});
+
+describe('HomeScreen radius refetch on spin (#55)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('re-issues the search on Spin Again when the radius changed since the last fetch', async () => {
+    const { getByPlaceholderText, getByTestId, rerender } = render(
+      <RootContext.Provider value={{ state: withResults(1600), dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+
+    // Perform a real search (records the fetched radius = 1600).
+    const input = getByPlaceholderText('What are you craving?');
+    fireEvent.changeText(input, 'pizza');
+    fireEvent(input, 'submitEditing');
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 1600));
+    mockSearchApi.mockClear();
+
+    // User widens Distance to 3 mi, then taps Spin Again.
+    rerender(
+      <RootContext.Provider value={{ state: withResults(4800), dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+    fireEvent.press(getByTestId('roulette-wheel'));
+
+    await waitFor(() =>
+      expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 4800)
+    );
+  });
+
+  it('does not re-issue the search on spin when the radius is unchanged', async () => {
+    const { getByPlaceholderText, getByTestId } = render(
+      <RootContext.Provider value={{ state: withResults(1600), dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+    const input = getByPlaceholderText('What are you craving?');
+    fireEvent.changeText(input, 'pizza');
+    fireEvent(input, 'submitEditing');
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalledWith('pizza', expect.anything(), null, 1600));
+    mockSearchApi.mockClear();
+
+    // Spin again without changing the radius → spins the existing set, no refetch.
+    fireEvent.press(getByTestId('roulette-wheel'));
+    expect(mockSearchApi).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Closes #55 (follow-up from #49 / PR #54, codex [P2]). The distance slider updated `filters.radiusMeters`, but both `useResults` search paths hardcoded the Yelp request `radius` to **1600 m**, so `applyFilters` only filtered a 1-mile result set client-side. On the GPS/coordinate path, picking a radius above 1 mi could never surface farther restaurants — they were never fetched. This wires the radius all the way through.

## Changes
- **Yelp request**: thread `radiusMeters` through `searchApi` / `searchApiWithResolver` → `searchParams.radius`, clamped to Yelp's **40,000 m** max at the API boundary.
- **Cache key**: include the radius (`:r<meters>`) in `generateCacheKey` so a 1-mile fetch can't satisfy a 25-mile request. Threaded through `getCachedResults` / `cacheResults`; omitted when `undefined` to preserve legacy keys.
- **Call sites**: pass `state.filters.radiusMeters` from the live screens (`SearchScreen`, `HomeScreen`). The unrouted legacy chain (`SearchInput → QuickActionsPanel`) keeps the 1600 m default.
- **Re-fetch on change**: `SearchScreen` refetches when the radius changes (applying a larger distance in the sheet), because radius changes *what Yelp returns* and a client-side re-filter can't add farther results. Guarded by a ref so it no-ops on mount / unrelated re-renders and can't loop (`handleSearch` dispatches `setResults`, not `filters`). **Scoped to SearchScreen** — HomeScreen's search auto-spins the wheel, so refetching on a filter nudge there would re-spin unexpectedly; the new radius applies on the next spin.

## Testing
- **Real hooks** (not reconstruction tests): `radiusMeters` reaches the Yelp `radius` param; defaults to 1600; clamps at 40000; cache key varies by radius and is stable for the same radius.
- **SearchScreen**: refetches with the new radius on a distance change; does **not** refetch when no term is active.
- Full suite: **41 suites / 381 tests green**. `tsc` unchanged (161 pre-existing baseline; 0 new — verified per-file against main).

## Notes
Purely JS/logic — no native change, so this is OTA-eligible once a build with `expo-updates` is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)