### PR TITLE
feat(modal): Spin Again + View All on the winner modal

### DIFF
--- a/__tests__/boot.test.tsx
+++ b/__tests__/boot.test.tsx
@@ -290,6 +290,8 @@ jest.mock('@react-navigation/native', () => ({
     navigate: jest.fn(),
     goBack: jest.fn(),
   }),
+  useIsFocused: () => true,
+  createNavigationContainerRef: () => ({ isReady: () => false, navigate: jest.fn() }),
 }));
 
 jest.mock('@react-navigation/native-stack', () => ({

--- a/__tests__/context/reducer.test.ts
+++ b/__tests__/context/reducer.test.ts
@@ -1,4 +1,4 @@
-import { appReducer, setSelectedBusiness, showBusinessModal, hideBusinessModal, setLastSearch, setLocation } from '../../context/reducer';
+import { appReducer, setSelectedBusiness, showBusinessModal, hideBusinessModal, setLastSearch, setLocation, requestSpin } from '../../context/reducer';
 import { initialAppState } from '../../context/state';
 import { ActionType } from '../../context/actions';
 import { YelpBusiness } from '../../types/yelp';
@@ -88,6 +88,32 @@ describe('appReducer', () => {
       expect(newState.location).toBe('Columbus, OH');
       expect(newState.results).toEqual([]);
       expect(newState.selectedBusiness).toEqual(mockBusiness);
+    });
+  });
+
+  describe('winner modal actions (Spin Again / View All)', () => {
+    it('showBusinessModal tags the source (spin winner vs plain detail)', () => {
+      const spin = appReducer(initialAppState, showBusinessModal('spin'));
+      expect(spin.isBusinessModalOpen).toBe(true);
+      expect(spin.businessModalSource).toBe('spin');
+
+      const detail = appReducer(initialAppState, showBusinessModal());
+      expect(detail.isBusinessModalOpen).toBe(true);
+      expect(detail.businessModalSource).toBe(null);
+    });
+
+    it('hideBusinessModal clears the source', () => {
+      const open = appReducer(initialAppState, showBusinessModal('spin'));
+      const closed = appReducer(open, hideBusinessModal());
+      expect(closed.isBusinessModalOpen).toBe(false);
+      expect(closed.businessModalSource).toBe(null);
+    });
+
+    it('requestSpin bumps spinRequestId', () => {
+      const s1 = appReducer(initialAppState, requestSpin());
+      expect(s1.spinRequestId).toBe(initialAppState.spinRequestId + 1);
+      const s2 = appReducer(s1, requestSpin());
+      expect(s2.spinRequestId).toBe(initialAppState.spinRequestId + 2);
     });
   });
 

--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -128,11 +128,23 @@ export function BusinessCardModal() {
     // "Spin Again": fade the card out to a translucent backdrop, ask Home to
     // re-spin the wheel (visible behind), and reveal the new winner on landing.
     const handleSpinAgain = () => {
+        // Nothing to spin (e.g. filters removed every match) → Home's handleSpin
+        // would no-op and never land, so don't enter the spinning state at all.
+        if (!state.results || state.results.length === 0) return;
         respinBaselineRef.current = spinHistory[0];
         setIsFlipped(false);
         setRespinning(true);
         dispatch(requestSpin());
     };
+
+    // Failsafe: never trap the user on the "Spinning…" overlay. If a requested
+    // spin doesn't land within a few seconds (Home couldn't spin, no handler,
+    // etc.), restore the card so it stays dismissable.
+    useEffect(() => {
+        if (!respinning) return;
+        const timeout = setTimeout(() => setRespinning(false), 5000);
+        return () => clearTimeout(timeout);
+    }, [respinning]);
 
     // "View All": close the winner modal and jump to the results list.
     const handleViewAll = () => {

--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -13,7 +13,8 @@ import {
 } from 'react-native';
 import {useSafeAreaInsets} from 'react-native-safe-area-context';
 import {RootContext} from '../../context/RootContext';
-import {hideBusinessModal} from '../../context/reducer';
+import {hideBusinessModal, requestSpin} from '../../context/reducer';
+import {navigate} from '../../navigation';
 import AppStyles from '../../AppStyles';
 import {supperClub} from '../../theme/supperClub';
 import FlipCard from './FlipCard';
@@ -42,8 +43,23 @@ export function BusinessCardModal() {
     const [isFlipped, setIsFlipped] = useState(false);
     const [imageViewerVisible, setImageViewerVisible] = useState(false);
     const [selectedImageIndex, setSelectedImageIndex] = useState(0);
+    const [respinning, setRespinning] = useState(false);
 
-    const {isBusinessModalOpen, selectedBusiness} = state;
+    const {isBusinessModalOpen, selectedBusiness, businessModalSource, spinHistory} = state;
+    // The action bar (Spin Again / View All) only belongs on the roulette-winner
+    // modal — not on plain detail views opened from Search / History / Favorites.
+    const isSpinWinner = businessModalSource === 'spin';
+
+    // Detect when a requested re-spin has landed: handleAutoSpinComplete on Home
+    // prepends a new spinHistory entry (a fresh object) and updates the winner.
+    // Comparing the head reference is cap-safe (spinHistory is capped at 10).
+    const respinBaselineRef = React.useRef<unknown>(undefined);
+    useEffect(() => {
+        if (respinning && spinHistory[0] !== respinBaselineRef.current) {
+            setRespinning(false);
+            setIsFlipped(false);
+        }
+    }, [spinHistory, respinning]);
 
     // Convert to BusinessProps for hooks
     const businessForHook: BusinessProps | null = selectedBusiness ? {
@@ -103,8 +119,26 @@ export function BusinessCardModal() {
     const is_open_now = business.hours?.[0]?.is_open_now ?? isOpen ?? null;
 
     const handleBackdropPress = () => {
+        // Don't let a stray backdrop tap dismiss mid-spin.
+        if (respinning) return;
         setIsFlipped(false);
         dispatch(hideBusinessModal());
+    };
+
+    // "Spin Again": fade the card out to a translucent backdrop, ask Home to
+    // re-spin the wheel (visible behind), and reveal the new winner on landing.
+    const handleSpinAgain = () => {
+        respinBaselineRef.current = spinHistory[0];
+        setIsFlipped(false);
+        setRespinning(true);
+        dispatch(requestSpin());
+    };
+
+    // "View All": close the winner modal and jump to the results list.
+    const handleViewAll = () => {
+        setIsFlipped(false);
+        dispatch(hideBusinessModal());
+        navigate('Search');
     };
 
     const handleClosePress = () => {
@@ -413,12 +447,19 @@ export function BusinessCardModal() {
                 onRequestClose={handleBackdropPress}
             >
                 <Pressable
-                    style={styles.backdrop}
+                    style={[styles.backdrop, respinning && styles.backdropRespinning]}
                     onPress={handleBackdropPress}
                     testID="modal-backdrop"
                 >
                     <View style={styles.modalContainer}>
-                        <Pressable onPress={(e) => e.stopPropagation()}>
+                        {respinning ? (
+                            // Card fades to a translucent backdrop so Home's wheel
+                            // is visible spinning behind; a hint sits at the bottom.
+                            <View style={styles.respinningHintWrap} pointerEvents="none">
+                                <Text style={styles.respinningHint}>Spinning the wheel…</Text>
+                            </View>
+                        ) : (
+                        <Pressable onPress={(e) => e.stopPropagation()} style={styles.contentColumn}>
                             <View style={{maxWidth: modalMaxWidth, width: modalMaxWidth}}>
                                 <FlipCard
                                     front={frontContent}
@@ -430,7 +471,32 @@ export function BusinessCardModal() {
                                     disableSwipeToFlip={true}
                                 />
                             </View>
+                            {isSpinWinner && (
+                                <View style={[styles.actionBar, {maxWidth: modalMaxWidth, width: modalMaxWidth}]}>
+                                    <Pressable
+                                        style={({pressed}) => [styles.winnerActionButton, styles.winnerActionPrimary, pressed && styles.winnerActionPressed]}
+                                        onPress={handleSpinAgain}
+                                        testID="modal-spin-again"
+                                        accessibilityRole="button"
+                                        accessibilityLabel="Spin again"
+                                    >
+                                        <Ionicons name="refresh" size={18} color="#FFFFFF"/>
+                                        <Text style={styles.winnerActionPrimaryText}>Spin Again</Text>
+                                    </Pressable>
+                                    <Pressable
+                                        style={({pressed}) => [styles.winnerActionButton, styles.winnerActionSecondary, pressed && styles.winnerActionPressed]}
+                                        onPress={handleViewAll}
+                                        testID="modal-view-all"
+                                        accessibilityRole="button"
+                                        accessibilityLabel="View all results"
+                                    >
+                                        <Ionicons name="list" size={18} color={supperClub.gold}/>
+                                        <Text style={styles.winnerActionSecondaryText}>View All</Text>
+                                    </Pressable>
+                                </View>
+                            )}
                         </Pressable>
+                        )}
                     </View>
                 </Pressable>
             </Modal>
@@ -464,6 +530,62 @@ const styles = StyleSheet.create({
     },
     flipCard: {
         // Empty - let content handle its own styling for 3D flip effect
+    },
+    backdropRespinning: {
+        // Translucent so Home's roulette wheel is visible spinning behind.
+        backgroundColor: 'rgba(6,3,4,0.28)',
+    },
+    respinningHintWrap: {
+        flex: 1,
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        paddingBottom: 96,
+    },
+    respinningHint: {
+        color: supperClub.text,
+        fontFamily: AppStyles.fonts.medium,
+        fontSize: 15,
+        letterSpacing: 0.3,
+        opacity: 0.92,
+    },
+    contentColumn: {
+        alignItems: 'center',
+    },
+    actionBar: {
+        flexDirection: 'row',
+        gap: 10,
+        marginTop: 14,
+    },
+    winnerActionButton: {
+        flex: 1,
+        flexDirection: 'row',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 8,
+        paddingVertical: 14,
+        borderRadius: 12,
+        minHeight: 48,
+    },
+    winnerActionPrimary: {
+        backgroundColor: supperClub.primary,
+    },
+    winnerActionSecondary: {
+        backgroundColor: supperClub.surfaceElevated,
+        borderWidth: 1,
+        borderColor: supperClub.borderSoft,
+    },
+    winnerActionPressed: {
+        opacity: 0.85,
+    },
+    winnerActionPrimaryText: {
+        color: '#FFFFFF',
+        fontFamily: AppStyles.fonts.medium,
+        fontSize: 15,
+    },
+    winnerActionSecondaryText: {
+        color: supperClub.gold,
+        fontFamily: AppStyles.fonts.medium,
+        fontSize: 15,
     },
     cardContent: {
         borderRadius: 16,

--- a/components/shared/__tests__/BusinessCardModal.test.tsx
+++ b/components/shared/__tests__/BusinessCardModal.test.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useContext } from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { BusinessCardModal } from '../BusinessCardModal';
 import { RootContext } from '../../../context/RootContext';
@@ -241,7 +241,13 @@ describe('BusinessCardModal', () => {
       render(
         <SafeAreaProvider initialMetrics={{ insets: { top: 0, left: 0, right: 0, bottom: 0 }, frame: { x: 0, y: 0, width: 0, height: 0 } }}>
           <RootContext.Provider value={{
-            state: { ...initialAppState, selectedBusiness: sampleBusiness, isBusinessModalOpen: true, businessModalSource: source },
+            state: {
+              ...initialAppState,
+              selectedBusiness: sampleBusiness,
+              isBusinessModalOpen: true,
+              businessModalSource: source,
+              results: [{ id: sampleBusiness.id } as any], // non-empty → Spin Again can proceed
+            },
             dispatch,
           }}>
             <BusinessCardModal />
@@ -279,6 +285,41 @@ describe('BusinessCardModal', () => {
 
       expect(dispatch).toHaveBeenCalledWith(hideBusinessModal());
       expect(navigate).toHaveBeenCalledWith('Search');
+    });
+
+    it('does not enter the spinning state when there are no results to spin', () => {
+      const dispatch = jest.fn();
+      const { getByTestId, queryByText } = render(
+        <SafeAreaProvider initialMetrics={{ insets: { top: 0, left: 0, right: 0, bottom: 0 }, frame: { x: 0, y: 0, width: 0, height: 0 } }}>
+          <RootContext.Provider value={{
+            state: { ...initialAppState, selectedBusiness: sampleBusiness, isBusinessModalOpen: true, businessModalSource: 'spin', results: [] },
+            dispatch,
+          }}>
+            <BusinessCardModal />
+          </RootContext.Provider>
+        </SafeAreaProvider>
+      );
+
+      fireEvent.press(getByTestId('modal-spin-again'));
+
+      expect(dispatch).not.toHaveBeenCalledWith(requestSpin());
+      expect(queryByText('Spinning the wheel…')).toBeNull();
+    });
+
+    it('failsafe: restores the card if a requested spin never lands', () => {
+      jest.useFakeTimers();
+      try {
+        const { getByTestId, getByText, queryByText } = renderWinner(jest.fn());
+        fireEvent.press(getByTestId('modal-spin-again'));
+        expect(getByText('Spinning the wheel…')).toBeTruthy();
+
+        act(() => { jest.advanceTimersByTime(5000); }); // spin never landed
+
+        expect(queryByText('Spinning the wheel…')).toBeNull();
+        expect(getByTestId('modal-spin-again')).toBeTruthy(); // card + bar restored
+      } finally {
+        jest.useRealTimers();
+      }
     });
   });
 });

--- a/components/shared/__tests__/BusinessCardModal.test.tsx
+++ b/components/shared/__tests__/BusinessCardModal.test.tsx
@@ -4,8 +4,13 @@ import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { BusinessCardModal } from '../BusinessCardModal';
 import { RootContext } from '../../../context/RootContext';
 import { initialAppState } from '../../../context/state';
-import { setSelectedBusiness, showBusinessModal } from '../../../context/reducer';
+import { setSelectedBusiness, showBusinessModal, hideBusinessModal, requestSpin } from '../../../context/reducer';
 import { YelpBusiness } from '../../../types/yelp';
+
+// The winner modal's "View All" navigates via the ref-based helper (the modal is
+// rendered outside the NavigationContainer).
+jest.mock('../../../navigation', () => ({ navigate: jest.fn() }));
+const { navigate } = require('../../../navigation');
 
 // Mock useBusinessHours to avoid Date mocking complexity in component tests
 jest.mock('../../../hooks/useBusinessHours', () => ({
@@ -228,6 +233,52 @@ describe('BusinessCardModal', () => {
     it('should match snapshot for Details view', () => {
       // Skip - component was redesigned to use flip card instead of tabs
       expect(true).toBe(true);
+    });
+  });
+
+  describe('winner action bar (Spin Again / View All)', () => {
+    const renderWinner = (dispatch: jest.Mock, source: 'spin' | null = 'spin') =>
+      render(
+        <SafeAreaProvider initialMetrics={{ insets: { top: 0, left: 0, right: 0, bottom: 0 }, frame: { x: 0, y: 0, width: 0, height: 0 } }}>
+          <RootContext.Provider value={{
+            state: { ...initialAppState, selectedBusiness: sampleBusiness, isBusinessModalOpen: true, businessModalSource: source },
+            dispatch,
+          }}>
+            <BusinessCardModal />
+          </RootContext.Provider>
+        </SafeAreaProvider>
+      );
+
+    it('shows the action bar only for the spin-winner modal', () => {
+      const spin = renderWinner(jest.fn(), 'spin');
+      expect(spin.getByTestId('modal-spin-again')).toBeTruthy();
+      expect(spin.getByTestId('modal-view-all')).toBeTruthy();
+
+      const detail = renderWinner(jest.fn(), null);
+      expect(detail.queryByTestId('modal-spin-again')).toBeNull();
+      expect(detail.queryByTestId('modal-view-all')).toBeNull();
+    });
+
+    it('Spin Again dispatches requestSpin and shows the spinning state', () => {
+      const dispatch = jest.fn();
+      const { getByTestId, getByText, queryByTestId } = renderWinner(dispatch);
+
+      fireEvent.press(getByTestId('modal-spin-again'));
+
+      expect(dispatch).toHaveBeenCalledWith(requestSpin());
+      // Card fades to the spinning hint (wheel visible behind); bar is gone.
+      expect(getByText('Spinning the wheel…')).toBeTruthy();
+      expect(queryByTestId('modal-spin-again')).toBeNull();
+    });
+
+    it('View All closes the modal and navigates to the results list', () => {
+      const dispatch = jest.fn();
+      const { getByTestId } = renderWinner(dispatch);
+
+      fireEvent.press(getByTestId('modal-view-all'));
+
+      expect(dispatch).toHaveBeenCalledWith(hideBusinessModal());
+      expect(navigate).toHaveBeenCalledWith('Search');
     });
   });
 });

--- a/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
+++ b/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
@@ -49,10 +49,13 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
       onResponderTerminationRequest={[Function]}
       onStartShouldSetResponder={[Function]}
       style={
-        {
-          "backgroundColor": "rgba(6,3,4,0.66)",
-          "flex": 1,
-        }
+        [
+          {
+            "backgroundColor": "rgba(6,3,4,0.66)",
+            "flex": 1,
+          },
+          false,
+        ]
       }
       testID="modal-backdrop"
     >
@@ -96,6 +99,11 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
           onResponderTerminate={[Function]}
           onResponderTerminationRequest={[Function]}
           onStartShouldSetResponder={[Function]}
+          style={
+            {
+              "alignItems": "center",
+            }
+          }
         >
           <View
             style={

--- a/context/actions.ts
+++ b/context/actions.ts
@@ -30,6 +30,7 @@ export enum ActionType {
 	HideBusinessModal,
 	ToggleCategoryFilter,
 	SetLastSearch,
+	RequestSpin,
 }
 
 // String constants as requested
@@ -133,10 +134,15 @@ export interface SetSelectedBusiness {
 
 export interface ShowBusinessModal {
 	type: ActionType.ShowBusinessModal;
+	payload: { source: 'spin' | null };
 }
 
 export interface HideBusinessModal {
 	type: ActionType.HideBusinessModal;
+}
+
+export interface RequestSpin {
+	type: ActionType.RequestSpin;
 }
 
 export interface SetFilters {
@@ -158,4 +164,4 @@ export interface ToggleCategoryFilter {
 	payload: { categoryAlias: string };
 }
 
-export type AppActions = SetCategories | SetDetail | SetFilter | SetFilters | ResetFilters | HydrateFilters | SetLocation | SetCoords | SetResults | SetShowFilter | AddFavorite | RemoveFavorite | HydrateFavorites | AddBlocked | RemoveBlocked | HydrateBlocked | AddHistory | ClearHistory | HydrateHistory | AddSpinHistory | SetSelectedBusiness | ShowBusinessModal | HideBusinessModal | ToggleCategoryFilter | SetLastSearch;
+export type AppActions = SetCategories | SetDetail | SetFilter | SetFilters | ResetFilters | HydrateFilters | SetLocation | SetCoords | SetResults | SetShowFilter | AddFavorite | RemoveFavorite | HydrateFavorites | AddBlocked | RemoveBlocked | HydrateBlocked | AddHistory | ClearHistory | HydrateHistory | AddSpinHistory | SetSelectedBusiness | ShowBusinessModal | HideBusinessModal | ToggleCategoryFilter | SetLastSearch | RequestSpin;

--- a/context/reducer.ts
+++ b/context/reducer.ts
@@ -30,6 +30,7 @@ import {
 	HideBusinessModal,
 	ToggleCategoryFilter,
 	SetLastSearch,
+	RequestSpin,
 } from "./actions";
 import { CategoryProps, BusinessProps } from "../hooks/useResults";
 import { YelpBusiness } from "../types/yelp";
@@ -217,11 +218,18 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 			return {
 				...state,
 				isBusinessModalOpen: true,
+				businessModalSource: action.payload.source,
 			};
 		case ActionType.HideBusinessModal:
 			return {
 				...state,
 				isBusinessModalOpen: false,
+				businessModalSource: null,
+			};
+		case ActionType.RequestSpin:
+			return {
+				...state,
+				spinRequestId: state.spinRequestId + 1,
 			};
 		case ActionType.SetFilters: {
 			const newFilters = {
@@ -386,12 +394,17 @@ export const setSelectedBusiness = (business: YelpBusiness | null): SetSelectedB
 	payload: { business },
 });
 
-export const showBusinessModal = (): ShowBusinessModal => ({
+export const showBusinessModal = (source: 'spin' | null = null): ShowBusinessModal => ({
 	type: ActionType.ShowBusinessModal,
+	payload: { source },
 });
 
 export const hideBusinessModal = (): HideBusinessModal => ({
 	type: ActionType.HideBusinessModal,
+});
+
+export const requestSpin = (): RequestSpin => ({
+	type: ActionType.RequestSpin,
 });
 
 export const setFilters = (filters: Partial<Filters>): SetFilters => ({

--- a/context/state.ts
+++ b/context/state.ts
@@ -34,6 +34,11 @@ export interface AppState {
 	spinHistory: SpinHistory[];
 	selectedBusiness: YelpBusiness | null;
 	isBusinessModalOpen: boolean;
+	// 'spin' when the business modal is showing a roulette winner (enables the
+	// in-modal Spin Again / View All action bar); null for plain detail views.
+	businessModalSource: 'spin' | null;
+	// Bumped by the modal's Spin Again to ask Home to re-spin the wheel.
+	spinRequestId: number;
 	lastSearch: LastSearch | null;
 }
 
@@ -77,5 +82,7 @@ export const initialAppState: AppState = {
 	spinHistory: [],
 	selectedBusiness: null,
 	isBusinessModalOpen: false,
+	businessModalSource: null,
+	spinRequestId: 0,
 	lastSearch: null,
 }

--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -1,4 +1,4 @@
-import {DarkTheme, DefaultTheme, NavigationContainer} from "@react-navigation/native";
+import {DarkTheme, DefaultTheme, NavigationContainer, createNavigationContainerRef} from "@react-navigation/native";
 import {createNativeStackNavigator} from "@react-navigation/native-stack";
 import {createBottomTabNavigator} from "@react-navigation/bottom-tabs";
 import * as React from "react";
@@ -13,9 +13,22 @@ import {HomeScreen} from "../screens/HomeScreen";
 import {SavedTabNavigator} from "./SavedTabNavigator";
 import AppStyles from "../AppStyles";
 
+// Ref so components rendered OUTSIDE the NavigationContainer (e.g. the global
+// BusinessCardModal in App.tsx) can navigate — used by the winner modal's
+// "View All" action to jump to the Search results list.
+export const navigationRef = createNavigationContainerRef<RootStackParamList>();
+
+export function navigate(name: keyof RootTabParamList) {
+    if (navigationRef.isReady()) {
+        // Tabs live under the "Root" screen of the root stack.
+        navigationRef.navigate('Root', {screen: name} as never);
+    }
+}
+
 export default function Navigation({colorScheme}: { colorScheme: ColorSchemeName }) {
     return (
         <NavigationContainer
+            ref={navigationRef}
             linking={LinkingConfiguration}
             theme={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
             <RootNavigator/>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useContext, useEffect } from 'react';
+import React, { useState, useContext, useEffect, useRef } from 'react';
 import {
   View,
   Text,
@@ -205,6 +205,17 @@ export const HomeScreen: React.FC = () => {
     runSearch: (term) => handleSearch(term),
   });
 
+  // The winner modal's "Spin Again" bumps spinRequestId; re-run the spin so the
+  // wheel animates (visible behind the translucent modal) and the modal reveals
+  // the new winner when it settles.
+  const prevSpinRequestId = useRef(state.spinRequestId);
+  useEffect(() => {
+    if (state.spinRequestId === prevSpinRequestId.current) return;
+    prevSpinRequestId.current = state.spinRequestId;
+    handleSpin();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.spinRequestId]);
+
   // Called when wheel finishes spinning animation
   const handleAutoSpinComplete = () => {
     setIsAutoSpinning(false);
@@ -236,7 +247,7 @@ export const HomeScreen: React.FC = () => {
       };
       dispatch(addSpinHistory(spinEntry));
       dispatch(setSelectedBusiness(selectedResult));
-      dispatch(showBusinessModal());
+      dispatch(showBusinessModal('spin'));
 
       // Clear selected result
       setSelectedResult(null);

--- a/screens/__tests__/HomeScreen.radius-spin.test.tsx
+++ b/screens/__tests__/HomeScreen.radius-spin.test.tsx
@@ -146,6 +146,23 @@ describe('HomeScreen radius refetch on spin (#55/#58)', () => {
     );
   });
 
+  it('re-spins the wheel when the winner modal requests a spin (spinRequestId bump)', () => {
+    const base = committedState('pizza', 1600, 1600); // has results, radius matches
+    const { queryAllByText, getAllByText, rerender } = render(
+      <RootContext.Provider value={{ state: base, dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+    expect(queryAllByText('Spinning...').length).toBe(0); // idle before the request
+    // The modal's Spin Again bumps spinRequestId; Home should start the wheel.
+    rerender(
+      <RootContext.Provider value={{ state: { ...base, spinRequestId: base.spinRequestId + 1 }, dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+    expect(getAllByText('Spinning...').length).toBeGreaterThan(0);
+  });
+
   it('does not auto-refetch on an idle radius change (no surprise spin)', () => {
     // Stale committed radius but the user has NOT spun — Home must stay put.
     render(


### PR DESCRIPTION
## Summary
When the roulette-winner modal is up, you can now **Spin Again** or **View All** right from the modal — no need to close it first.

The winner modal is a **global native RN `<Modal>`** (rendered in `App.tsx`, a separate OS layer), so Home's buttons genuinely can't be raised above it with z-index. The actions are rendered **inside the modal overlay** instead (same result, correct mechanism), and only for the **spin-winner** modal — a `source: 'spin'` flag on `showBusinessModal`, so plain detail views opened from Search/History/Favorites don't get the bar.

## Behavior
- **Spin Again** (the flourish): the card fades to a translucent backdrop so Home's roulette wheel is visible **spinning behind it**, then the new winner's card reveals when the spin lands. Wiring: the modal bumps a `spinRequestId`; Home reacts by re-running its existing spin; completion is detected via the `spinHistory` head reference (cap-safe, works even if the same restaurant is re-picked).
- **View All**: closes the modal and jumps to the results list. The modal sits outside the `NavigationContainer`, so it navigates through a `createNavigationContainerRef` helper.

## State
- `state.businessModalSource: 'spin' | null` (drives the action bar) and `state.spinRequestId: number` (modal→Home spin signal), plus a `requestSpin` action. `showBusinessModal(source?)` now takes an optional source (existing no-arg callers default to `null`).

## Testing
- **reducer**: source tagging on show/hide, `requestSpin` bump.
- **modal**: action bar only on the spin source; Spin Again → `requestSpin` + spinning state (card hidden, hint shown); View All → hide + `navigate('Search')`.
- **Home**: a `spinRequestId` bump starts the wheel.
- Full suite **418 green**; `tsc` net **−1** (zero new).

## Notes
Pure JS/state — no native change, OTA-eligible. The translucent-wheel-behind flourish is a first cut; easy to tune (backdrop opacity, hint copy, add a fade animation) once you see it on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)