### PR TITLE
fix(stability): root ErrorBoundary + guard spin haptics (silent spin crash)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import { ToastProvider } from "./context/ToastContext";
 import { StatusBar } from "expo-status-bar";
 import { BusinessCardModal } from "./components/shared/BusinessCardModal";
 import DevStorageDebug from "./components/shared/DevStorageDebug";
+import { ErrorBoundary } from "./components/shared/ErrorBoundary";
 
 // Match splash screen background color to prevent white flash
 const SPLASH_BACKGROUND = "#1B5E20";
@@ -36,13 +37,15 @@ export default function App() {
 				<SafeAreaProvider>
 					<RootContext.Provider value={contextValue}>
 						<ToastProvider>
-							<Navigation colorScheme={colorScheme} />
-							<StatusBar
-								backgroundColor="transparent"
-								translucent
-							/>
-							<BusinessCardModal />
-							<DevStorageDebug />
+							<ErrorBoundary>
+								<Navigation colorScheme={colorScheme} />
+								<StatusBar
+									backgroundColor="transparent"
+									translucent
+								/>
+								<BusinessCardModal />
+								<DevStorageDebug />
+							</ErrorBoundary>
 						</ToastProvider>
 					</RootContext.Provider>
 				</SafeAreaProvider>

--- a/components/RouletteWheel.tsx
+++ b/components/RouletteWheel.tsx
@@ -62,8 +62,12 @@ export const RouletteWheel: React.FC<RouletteWheelProps> = ({
       duration: 1400,
       useNativeDriver: true,
     }).start(async () => {
+      // Haptics can reject/throw on some devices; never let it abort the spin
+      // completion (which would leave the wheel stuck and never open the result).
       if (Platform.OS === 'ios') {
-        await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        try {
+          await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        } catch {}
       }
       setIsSpinning(false);
       spinAnim.setValue(0);
@@ -82,7 +86,9 @@ export const RouletteWheel: React.FC<RouletteWheelProps> = ({
     if (disabled || isSpinning) return;
 
     if (Platform.OS === 'ios') {
-      await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      try {
+        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      } catch {}
     }
 
     Animated.sequence([

--- a/components/shared/ErrorBoundary.tsx
+++ b/components/shared/ErrorBoundary.tsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { View, Text, Pressable, ScrollView, StyleSheet } from 'react-native';
+import { supperClub } from '../../theme/supperClub';
+import { logSafe } from '../../utils/log';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+/**
+ * Root error boundary. Without it, an uncaught render/lifecycle error in a
+ * release build silently closes the app (no red screen, no report). This keeps
+ * the app alive and surfaces the error so a crash can actually be diagnosed —
+ * catch it, show it, offer a way back.
+ *
+ * Note: React error boundaries only catch errors thrown during render /
+ * lifecycle / child hooks — NOT inside async callbacks or event handlers.
+ */
+export class ErrorBoundary extends React.Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: { componentStack: string }) {
+    logSafe('[ErrorBoundary] caught render error', {
+      message: error?.message,
+      stack: error?.stack,
+      componentStack: info?.componentStack,
+    });
+  }
+
+  handleReset = () => {
+    this.setState({ error: null });
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    return (
+      <View style={styles.container} testID="error-boundary">
+        <Text style={styles.title}>Something went wrong</Text>
+        <Text style={styles.subtitle}>
+          The screen hit an unexpected error. Details below — please share them so we can fix it.
+        </Text>
+        <ScrollView style={styles.detailScroll} contentContainerStyle={styles.detailContent}>
+          <Text style={styles.detailText}>{error.message || String(error)}</Text>
+          {!!error.stack && <Text style={styles.stackText}>{error.stack}</Text>}
+        </ScrollView>
+        <Pressable style={styles.button} onPress={this.handleReset} accessibilityRole="button">
+          <Text style={styles.buttonText}>Try again</Text>
+        </Pressable>
+      </View>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: supperClub.background,
+    padding: 24,
+    justifyContent: 'center',
+  },
+  title: {
+    fontSize: 22,
+    fontFamily: 'Georgia',
+    color: supperClub.textPrimary,
+    marginBottom: 8,
+  },
+  subtitle: {
+    fontSize: 14,
+    color: supperClub.textMuted,
+    marginBottom: 16,
+  },
+  detailScroll: {
+    maxHeight: 260,
+    backgroundColor: supperClub.surface,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: supperClub.borderSoft,
+  },
+  detailContent: { padding: 12 },
+  detailText: {
+    fontSize: 13,
+    color: supperClub.error,
+    marginBottom: 8,
+  },
+  stackText: {
+    fontSize: 11,
+    color: supperClub.textMuted,
+    fontFamily: 'Courier',
+  },
+  button: {
+    marginTop: 20,
+    backgroundColor: supperClub.primary,
+    borderRadius: 12,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  buttonText: {
+    color: '#FFFFFF',
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/components/shared/__tests__/ErrorBoundary.test.tsx
+++ b/components/shared/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+const Boom = ({ crash }: { crash: boolean }) => {
+  if (crash) throw new Error('kaboom');
+  return <Text>child ok</Text>;
+};
+
+describe('ErrorBoundary', () => {
+  it('renders children when nothing throws', () => {
+    const { getByText, queryByTestId } = render(
+      <ErrorBoundary>
+        <Text>hello</Text>
+      </ErrorBoundary>
+    );
+    expect(getByText('hello')).toBeTruthy();
+    expect(queryByTestId('error-boundary')).toBeNull();
+  });
+
+  it('shows a visible fallback with the error message instead of crashing', () => {
+    // React logs the caught error to console.error; silence it for a clean run.
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const { getByTestId, getByText } = render(
+      <ErrorBoundary>
+        <Boom crash />
+      </ErrorBoundary>
+    );
+    expect(getByTestId('error-boundary')).toBeTruthy();
+    expect(getByText('kaboom')).toBeTruthy();
+    expect(getByText('Try again')).toBeTruthy();
+    spy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Context
Reports of a **silent crash on spin, no warning**, on some devices. The app has **no crash reporting**, so an uncaught render/lifecycle error in a release build just closes the app — nothing to diagnose from. Per systematic debugging, step one for a silent crash is to **make it visible** and remove a known suspect; this is instrumentation + hardening, **not** a confirmed root-cause fix yet.

## Changes
- **Root `ErrorBoundary`** (in `App.tsx`, inside the providers): catches render/lifecycle errors, keeps the app alive, and shows the error message + stack on screen so a tester can screenshot it. The spin → winner-modal flow mounts `FlipCard` (`react-native-reanimated`), a prime render-crash locus.
- **Guard `RouletteWheel` haptics** (`expo-haptics`) in try/catch. Haptics can reject on some devices; a throw in the spin-completion callback previously aborted completion (stuck wheel). Now it can't.

## What this does / doesn't do
- ✅ Turns a silent app-close into a visible, screenshot-able error (for JS render crashes).
- ✅ Removes haptics as a crash/hang vector.
- ❌ Does not catch async/event-handler errors (React boundaries only catch render/lifecycle) — if the crash is there or native, we'll need the device crash log.

## Testing
- ErrorBoundary: renders children normally; shows the fallback + error message when a child throws.
- Full suite **430 green / 44 suites**; `tsc` net −1.

Pure JS — **OTA-deliverable**, so it can go out on the current build to start capturing the real error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)