### PR TITLE
fix(spin): remove expo-haptics call crashing the app on iOS 26 (SIGABRT)

### DIFF
--- a/components/RouletteWheel.tsx
+++ b/components/RouletteWheel.tsx
@@ -1,8 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
-import { View, StyleSheet, Pressable, Animated, Platform } from 'react-native';
+import { View, StyleSheet, Pressable, Animated } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Svg, { Path, Circle, G } from 'react-native-svg';
-import * as Haptics from 'expo-haptics';
 import {
   supperClub,
   supperClubPalette,
@@ -61,14 +60,7 @@ export const RouletteWheel: React.FC<RouletteWheelProps> = ({
       toValue: 1,
       duration: 1400,
       useNativeDriver: true,
-    }).start(async () => {
-      // Haptics can reject/throw on some devices; never let it abort the spin
-      // completion (which would leave the wheel stuck and never open the result).
-      if (Platform.OS === 'ios') {
-        try {
-          await Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
-        } catch {}
-      }
+    }).start(() => {
       setIsSpinning(false);
       spinAnim.setValue(0);
       onDone?.();
@@ -82,15 +74,13 @@ export const RouletteWheel: React.FC<RouletteWheelProps> = ({
     }
   }, [isAutoSpinning]);
 
-  const handlePress = async () => {
+  const handlePress = () => {
     if (disabled || isSpinning) return;
 
-    if (Platform.OS === 'ios') {
-      try {
-        await Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
-      } catch {}
-    }
-
+    // NOTE: expo-haptics was removed here — on iOS 26 (iPhone 17) the CoreHaptics
+    // call threw an Obj-C exception that React Native's New-Arch TurboModule
+    // bridge rethrew uncaught, aborting the app (SIGABRT) the instant spin was
+    // tapped. A JS try/catch can't catch a native abort, so the call is gone.
     Animated.sequence([
       Animated.timing(scaleAnim, { toValue: 0.95, duration: 100, useNativeDriver: true }),
       Animated.timing(scaleAnim, { toValue: 1, duration: 100, useNativeDriver: true }),


### PR DESCRIPTION
## Root cause (from the device crash log)
iPhone 17 / iOS 26.5.2, TestFlight build 5:

```
EXC_CRASH (SIGABRT) — abort() called
triggered thread queue: com.meta.react.turbomodulemanager.queue
  abort ← _objc_terminate ← __cxa_rethrow ← objc_exception_rethrow
        ← facebook::react::ObjCTurboModule::performVoidMethodInvocation
concurrent thread (com.apple.haptics.metrics.shared):
  +[CHMetrics doHandleErrorCode:] → +[AVAudioSession sharedInstance]
```

The **expo-haptics** call in the roulette wheel throws an **Objective-C exception via CoreHaptics on iOS 26**, and React Native's **New-Architecture TurboModule bridge rethrows it uncaught**, aborting the process the **instant spin is tapped** (`Haptics.impactAsync` on press — matches the "instant on tap" report).

Important: a JS `try/catch` **cannot** catch this — it's a native abort on the TurboModule queue, so the earlier guard (#62) didn't fix it. The call itself has to go.

## Fix
Remove both haptics calls (on tap + on spin-complete) and the now-unused `Platform` import from `RouletteWheel`. `expo-haptics` stays installed but unused.

- **Pure JS → OTA-deliverable.** Ships to the crashing build 5 with no rebuild.
- Re-enabling haptics later needs an expo-haptics / iOS-26 fix + a native build.

## Testing
- Full suite **430 green / 44 suites**; `tsc` net −1. Wheel spin/animation path unchanged apart from the removed native call.

## Note
This supersedes the haptics half of #62 (the JS guard). The #62 ErrorBoundary stays — still valuable for future render crashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)