### PR TITLE
fix(modal): hooks-order crash opening the winner modal (Rendered more hooks)

### DIFF
--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -61,6 +61,16 @@ export function BusinessCardModal() {
         }
     }, [spinHistory, respinning]);
 
+    // Failsafe: never trap the user on the "Spinning…" overlay. If a requested
+    // spin doesn't land within a few seconds (Home couldn't spin, no handler,
+    // etc.), restore the card so it stays dismissable. Must stay above the
+    // early return below — all hooks run on every render (Rules of Hooks).
+    useEffect(() => {
+        if (!respinning) return;
+        const timeout = setTimeout(() => setRespinning(false), 5000);
+        return () => clearTimeout(timeout);
+    }, [respinning]);
+
     // Convert to BusinessProps for hooks
     const businessForHook: BusinessProps | null = selectedBusiness ? {
         id: selectedBusiness.id,
@@ -136,15 +146,6 @@ export function BusinessCardModal() {
         setRespinning(true);
         dispatch(requestSpin());
     };
-
-    // Failsafe: never trap the user on the "Spinning…" overlay. If a requested
-    // spin doesn't land within a few seconds (Home couldn't spin, no handler,
-    // etc.), restore the card so it stays dismissable.
-    useEffect(() => {
-        if (!respinning) return;
-        const timeout = setTimeout(() => setRespinning(false), 5000);
-        return () => clearTimeout(timeout);
-    }, [respinning]);
 
     // "View All": close the winner modal and jump to the results list.
     const handleViewAll = () => {

--- a/components/shared/__tests__/BusinessCardModal.test.tsx
+++ b/components/shared/__tests__/BusinessCardModal.test.tsx
@@ -140,6 +140,27 @@ describe('BusinessCardModal', () => {
     expect(queryByTestId('modal-backdrop')).toBeNull();
   });
 
+  it('opens without a rules-of-hooks error on the null → selected transition', () => {
+    // Regression: a useEffect sat after the `if (!selectedBusiness) return null`
+    // early return, so opening the modal (null → set) rendered more hooks than
+    // the closed render and threw "Rendered more hooks than during the previous
+    // render." The rerender below throws if that regresses.
+    const wrap = (state: any) => (
+      <SafeAreaProvider initialMetrics={{ insets: { top: 0, left: 0, right: 0, bottom: 0 }, frame: { x: 0, y: 0, width: 0, height: 0 } }}>
+        <RootContext.Provider value={{ state, dispatch: jest.fn() }}>
+          <BusinessCardModal />
+        </RootContext.Provider>
+      </SafeAreaProvider>
+    );
+    const { rerender, queryByTestId, getByTestId } = render(
+      wrap({ ...initialAppState, selectedBusiness: null, isBusinessModalOpen: false })
+    );
+    expect(queryByTestId('modal-backdrop')).toBeNull();
+
+    rerender(wrap({ ...initialAppState, selectedBusiness: sampleBusiness, isBusinessModalOpen: true }));
+    expect(getByTestId('modal-backdrop')).toBeTruthy();
+  });
+
   it('should render BusinessQuickInfo by default', () => {
     const { getAllByText } = render(
       <TestHarness>


### PR DESCRIPTION
## What
The #62 ErrorBoundary surfaced the next crash after the haptics fix (#63): opening the winner modal threw **"Rendered more hooks than during the previous render."** (screenshot from the device confirmed it.)

## Root cause
`BusinessCardModal`'s Spin-Again **failsafe `useEffect` was placed *after*** the early return:
```
if (!selectedBusiness || !businessForHook) return null;   // early return
...
useEffect(() => { /* failsafe timeout */ }, [respinning]); // ← after the return
```
- Modal closed (`selectedBusiness` null) → early-return → failsafe effect not called.
- Spin opens it (`selectedBusiness` null → set) → effect **is** called → more hooks than the previous render → React throws (Rules of Hooks).

The haptics crash (#63) had been aborting on tap *before* the modal rendered, so this was masked until now.

## Fix
Move the failsafe `useEffect` up with the other hooks, above the early return. Hook count is now stable across renders. No behavior change.

## Test
Added a regression test: render the modal **closed**, then re-render **open** (the null → set transition). With the effect misplaced this rerender throws; now it passes.

- Full suite **431 green / 44 suites**; `tsc` net −1.
- Pure JS — **OTA-deliverable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)