### PR TITLE
fix(modal): pin winner actions to bottom so they're visible

### DIFF
--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -464,7 +464,7 @@ export function BusinessCardModal() {
                     onPress={handleBackdropPress}
                     testID="modal-backdrop"
                 >
-                    <View style={styles.modalContainer}>
+                    <View style={[styles.modalContainer, isSpinWinner && !respinning && {paddingBottom: insets.bottom + 96}]}>
                         {respinning ? (
                             // Card fades to a translucent backdrop so Home's wheel
                             // is visible spinning behind; a hint sits at the bottom.
@@ -484,33 +484,40 @@ export function BusinessCardModal() {
                                     disableSwipeToFlip={true}
                                 />
                             </View>
-                            {isSpinWinner && (
-                                <View style={[styles.actionBar, {maxWidth: modalMaxWidth, width: modalMaxWidth}]}>
-                                    <Pressable
-                                        style={({pressed}) => [styles.winnerActionButton, styles.winnerActionPrimary, pressed && styles.winnerActionPressed]}
-                                        onPress={handleSpinAgain}
-                                        testID="modal-spin-again"
-                                        accessibilityRole="button"
-                                        accessibilityLabel="Spin again"
-                                    >
-                                        <Ionicons name="refresh" size={18} color="#FFFFFF"/>
-                                        <Text style={styles.winnerActionPrimaryText}>Spin Again</Text>
-                                    </Pressable>
-                                    <Pressable
-                                        style={({pressed}) => [styles.winnerActionButton, styles.winnerActionSecondary, pressed && styles.winnerActionPressed]}
-                                        onPress={handleViewAll}
-                                        testID="modal-view-all"
-                                        accessibilityRole="button"
-                                        accessibilityLabel="View all results"
-                                    >
-                                        <Ionicons name="list" size={18} color={supperClub.gold}/>
-                                        <Text style={styles.winnerActionSecondaryText}>View All</Text>
-                                    </Pressable>
-                                </View>
-                            )}
                         </Pressable>
                         )}
                     </View>
+
+                    {/* Winner actions pinned to the bottom of the overlay so they're
+                        always visible and tappable above the (tall) card, regardless
+                        of card height. modalContainer reserves paddingBottom for them. */}
+                    {isSpinWinner && !respinning && (
+                        <Pressable
+                            onPress={(e) => e.stopPropagation()}
+                            style={[styles.pinnedActionBar, {bottom: insets.bottom + 16, left: H_PADDING, right: H_PADDING}]}
+                        >
+                            <Pressable
+                                style={({pressed}) => [styles.winnerActionButton, styles.winnerActionPrimary, pressed && styles.winnerActionPressed]}
+                                onPress={handleSpinAgain}
+                                testID="modal-spin-again"
+                                accessibilityRole="button"
+                                accessibilityLabel="Spin again"
+                            >
+                                <Ionicons name="refresh" size={18} color="#FFFFFF"/>
+                                <Text style={styles.winnerActionPrimaryText}>Spin Again</Text>
+                            </Pressable>
+                            <Pressable
+                                style={({pressed}) => [styles.winnerActionButton, styles.winnerActionSecondary, pressed && styles.winnerActionPressed]}
+                                onPress={handleViewAll}
+                                testID="modal-view-all"
+                                accessibilityRole="button"
+                                accessibilityLabel="View all results"
+                            >
+                                <Ionicons name="list" size={18} color={supperClub.gold}/>
+                                <Text style={styles.winnerActionSecondaryText}>View All</Text>
+                            </Pressable>
+                        </Pressable>
+                    )}
                 </Pressable>
             </Modal>
 
@@ -564,10 +571,10 @@ const styles = StyleSheet.create({
     contentColumn: {
         alignItems: 'center',
     },
-    actionBar: {
+    pinnedActionBar: {
+        position: 'absolute',
         flexDirection: 'row',
         gap: 10,
-        marginTop: 14,
     },
     winnerActionButton: {
         flex: 1,

--- a/components/shared/BusinessCardModal.tsx
+++ b/components/shared/BusinessCardModal.tsx
@@ -492,31 +492,33 @@ export function BusinessCardModal() {
                         always visible and tappable above the (tall) card, regardless
                         of card height. modalContainer reserves paddingBottom for them. */}
                     {isSpinWinner && !respinning && (
-                        <Pressable
-                            onPress={(e) => e.stopPropagation()}
-                            style={[styles.pinnedActionBar, {bottom: insets.bottom + 16, left: H_PADDING, right: H_PADDING}]}
-                        >
+                        <View style={[styles.pinnedActionBarWrap, {bottom: insets.bottom + 16}]} pointerEvents="box-none">
                             <Pressable
-                                style={({pressed}) => [styles.winnerActionButton, styles.winnerActionPrimary, pressed && styles.winnerActionPressed]}
-                                onPress={handleSpinAgain}
-                                testID="modal-spin-again"
-                                accessibilityRole="button"
-                                accessibilityLabel="Spin again"
+                                onPress={(e) => e.stopPropagation()}
+                                style={[styles.pinnedActionBar, {width: modalMaxWidth}]}
                             >
-                                <Ionicons name="refresh" size={18} color="#FFFFFF"/>
-                                <Text style={styles.winnerActionPrimaryText}>Spin Again</Text>
+                                <Pressable
+                                    style={({pressed}) => [styles.winnerActionButton, styles.winnerActionPrimary, pressed && styles.winnerActionPressed]}
+                                    onPress={handleSpinAgain}
+                                    testID="modal-spin-again"
+                                    accessibilityRole="button"
+                                    accessibilityLabel="Spin again"
+                                >
+                                    <Ionicons name="refresh" size={18} color="#FFFFFF"/>
+                                    <Text style={styles.winnerActionPrimaryText}>Spin Again</Text>
+                                </Pressable>
+                                <Pressable
+                                    style={({pressed}) => [styles.winnerActionButton, styles.winnerActionSecondary, pressed && styles.winnerActionPressed]}
+                                    onPress={handleViewAll}
+                                    testID="modal-view-all"
+                                    accessibilityRole="button"
+                                    accessibilityLabel="View all results"
+                                >
+                                    <Ionicons name="list" size={18} color={supperClub.gold}/>
+                                    <Text style={styles.winnerActionSecondaryText}>View All</Text>
+                                </Pressable>
                             </Pressable>
-                            <Pressable
-                                style={({pressed}) => [styles.winnerActionButton, styles.winnerActionSecondary, pressed && styles.winnerActionPressed]}
-                                onPress={handleViewAll}
-                                testID="modal-view-all"
-                                accessibilityRole="button"
-                                accessibilityLabel="View all results"
-                            >
-                                <Ionicons name="list" size={18} color={supperClub.gold}/>
-                                <Text style={styles.winnerActionSecondaryText}>View All</Text>
-                            </Pressable>
-                        </Pressable>
+                        </View>
                     )}
                 </Pressable>
             </Modal>
@@ -571,8 +573,14 @@ const styles = StyleSheet.create({
     contentColumn: {
         alignItems: 'center',
     },
-    pinnedActionBar: {
+    pinnedActionBarWrap: {
         position: 'absolute',
+        left: 0,
+        right: 0,
+        alignItems: 'center',
+        paddingHorizontal: 12,
+    },
+    pinnedActionBar: {
         flexDirection: 'row',
         gap: 10,
     },

--- a/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
+++ b/components/shared/__tests__/__snapshots__/BusinessCardModal.test.tsx.snap
@@ -61,12 +61,15 @@ exports[`BusinessCardModal snapshots should match snapshot for QuickInfo view 1`
     >
       <View
         style={
-          {
-            "alignItems": "center",
-            "flex": 1,
-            "justifyContent": "center",
-            "paddingHorizontal": 12,
-          }
+          [
+            {
+              "alignItems": "center",
+              "flex": 1,
+              "justifyContent": "center",
+              "paddingHorizontal": 12,
+            },
+            false,
+          ]
         }
       >
         <View


### PR DESCRIPTION
## Problem
"Spin Again" / "View All" weren't showing on the winner modal. They were **rendering** (the `isSpinWinner`/`showBusinessModal('spin')` logic is correct) but placed **below the card in a vertically-centered column**. The winner card is tall (`cardMinHeight = imageSize/2 + 120` + all the detail rows), so on real devices (iPhone 17) the bar overflowed **off the bottom of the screen** — present but unreachable.

## Fix
Pin the action bar **absolutely to the bottom of the overlay**, above the card (rendered after it), inset by the safe area, and reserve matching `paddingBottom` on the modal container so the centered card doesn't sit under it. Now the bar is always visible + tappable regardless of card height — what "buttons above the modal" actually needs. Wrapped in a `stopPropagation` Pressable so taps on the bar don't dismiss the modal.

No change to *when* the bar shows (spin-winner only) or what the buttons do.

## Testing
- Existing action-bar behavior tests still pass (renders only for spin source; Spin Again → requestSpin + spinning state; View All → hide + navigate; failsafe; no-results guard).
- Snapshot updated (the container style is now an array).
- Full suite **431 green / 44 suites**; `tsc` net −1.
- Layout visibility itself is device-verified (can't assert pixel layout in unit tests).

Pure JS — **OTA-deliverable**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)