### PR TITLE
fix(saved): restyle Saved tab bar to Supper Club

### DIFF
--- a/navigation/SavedTabNavigator.tsx
+++ b/navigation/SavedTabNavigator.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import { SavedTabParamList } from '../types';
 import AppStyles from '../AppStyles';
+import { supperClub } from '../theme/supperClub';
 import FavoritesScreen from '../screens/FavoritesScreen';
 import BlockedScreen from '../screens/BlockedScreen';
 import HistoryScreen from '../screens/HistoryScreen';
@@ -13,19 +14,19 @@ const SavedTabs = createMaterialTopTabNavigator<SavedTabParamList>();
 
 export function SavedTabNavigator() {
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: AppStyles.color.white }} edges={['top']}>
+    <SafeAreaView style={{ flex: 1, backgroundColor: supperClub.background }} edges={['top']}>
       <SavedTabs.Navigator
         initialRouteName="Favorites"
         screenOptions={{
-          tabBarActiveTintColor: AppStyles.color.roulette.accent,
-          tabBarInactiveTintColor: AppStyles.color.greylight,
+          tabBarActiveTintColor: supperClub.gold,
+          tabBarInactiveTintColor: supperClub.textMuted,
           tabBarStyle: {
-            backgroundColor: AppStyles.color.white,
+            backgroundColor: supperClub.background,
             borderBottomWidth: 1,
-            borderBottomColor: AppStyles.color.background,
+            borderBottomColor: supperClub.borderSoft,
           },
         tabBarIndicatorStyle: {
-          backgroundColor: AppStyles.color.roulette.accent,
+          backgroundColor: supperClub.gold,
           height: 3,
         },
         tabBarLabelStyle: {


### PR DESCRIPTION
## Problem
The Saved section looked off. Its three screens (Favorites / Blocked / History) are already Supper Club dark, but the **`SavedTabNavigator` chrome was never migrated** — a white `SafeAreaView` + white top tab bar with the old `roulette.accent` / `greylight` tints, sitting on top of the dark screens.

## Fix
Swap the navigator palette to Supper Club:
- SafeAreaView + tab bar background → `supperClub.background` (espresso)
- active tint + indicator → `supperClub.gold`
- inactive tint → `supperClub.textMuted`
- divider → `supperClub.borderSoft`

Fonts unchanged. Screens untouched (already themed).

## Testing
- Full suite **431 green / 44 suites**; `tsc` net −1.
- Visual — device/simulator verify.

## Related (not in this PR)
The **main bottom tab bar** (`navigation/index.tsx`) is on the same old palette (white bg, `AppStyles.color.primary`/`gray500`). Left out since only the Saved views were reported — easy follow-up if you want it migrated too (needs an accent decision: gold vs magenta).

Pure JS — OTA-deliverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)