### PR TITLE
fix(nav): restyle bottom tab bar to Supper Club

### DIFF
--- a/navigation/index.tsx
+++ b/navigation/index.tsx
@@ -12,6 +12,7 @@ import {SearchScreen} from "../screens/SearchScreen";
 import {HomeScreen} from "../screens/HomeScreen";
 import {SavedTabNavigator} from "./SavedTabNavigator";
 import AppStyles from "../AppStyles";
+import { supperClub } from "../theme/supperClub";
 
 // Ref so components rendered OUTSIDE the NavigationContainer (e.g. the global
 // BusinessCardModal in App.tsx) can navigate — used by the winner modal's
@@ -62,18 +63,18 @@ function BottomTabNavigator() {
         <BottomTabs.Navigator
             initialRouteName="Home"
             screenOptions={{
-                tabBarActiveTintColor: AppStyles.color.primary,
-                tabBarInactiveTintColor: AppStyles.color.gray500,
+                tabBarActiveTintColor: supperClub.gold,
+                tabBarInactiveTintColor: supperClub.textMuted,
                 tabBarStyle: {
-                    backgroundColor: AppStyles.color.white,
+                    backgroundColor: supperClub.background,
                     borderTopWidth: 1,
-                    borderTopColor: AppStyles.color.border,
+                    borderTopColor: supperClub.borderSoft,
                     height: Platform.OS === 'ios' ? 88 : 60, // Extra height for iOS safe area
                     paddingTop: 8,
                     paddingBottom: Platform.OS === 'ios' ? 28 : 8,
                     ...Platform.select({
                         ios: {
-                            shadowColor: AppStyles.color.shadow,
+                            shadowColor: '#000',
                             shadowOffset: {width: 0, height: -2},
                             shadowRadius: 8,
                             shadowOpacity: 0.1,


### PR DESCRIPTION
## What
The last bit of light-theme chrome from the theme promotion: the **bottom tab bar** (Home / Search / Saved) was still white with the old `primary`/`gray500` tints, clashing with the dark app.

## Change
Migrate `navigation/index.tsx` bottom-tab `screenOptions` to Supper Club:
- background → `supperClub.background` (espresso)
- active tint → `supperClub.gold` (matches the Saved tabs, #67)
- inactive tint → `supperClub.textMuted`
- top divider → `supperClub.borderSoft`
- shadowColor → `#000`

Fonts/layout unchanged. `caption2` carries no `color`, so the tab tints apply to the labels cleanly.

## Testing
- Full suite **431 green / 44 suites**; `tsc` net −1.
- Visual — device verify.

Pure JS — OTA-deliverable. Completes the dark-theme migration of the app's nav chrome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)