### PR TITLE
fix(history): guard non-array categories on history item tap (crash)

### DIFF
--- a/screens/HistoryScreen.tsx
+++ b/screens/HistoryScreen.tsx
@@ -38,6 +38,10 @@ const HistoryScreen: React.FC = () => {
   };
 
   const handleHistoryItemPress = (item: HistoryItem) => {
+    // Persisted history is untrusted — older/corrupt entries may store
+    // filters.categories as a non-array, which crashed .map() on tap.
+    const rawCategories = item.context?.filters?.categories;
+    const categoryList = Array.isArray(rawCategories) ? rawCategories : [];
     // Convert HistoryItem to YelpBusiness format for the modal
     const business = {
       id: item.businessId,
@@ -49,7 +53,7 @@ const HistoryScreen: React.FC = () => {
         city: item.context?.locationText || '',
         display_address: [item.context?.locationText || ''].filter(Boolean),
       },
-      categories: (item.context?.filters?.categories || []).map(cat => ({ title: cat, alias: cat })),
+      categories: categoryList.map(cat => ({ title: cat, alias: cat })),
       is_closed: false,
       url: `https://www.yelp.com/biz/${item.businessId}`,
       phone: '',


### PR DESCRIPTION
## Crash
Tapping a **History** item threw:
```
TypeError: (item.context?.filters?.categories || []).map is not a function (it is undefined)
```
The `|| []` fallback only catches `null`/`undefined`. Persisted/older history entries can store `filters.categories` as a **non-array** truthy value, so `|| []` returns it and `.map()` throws.

## Fix
`Array.isArray()` guard before mapping in `handleHistoryItemPress`. Persisted data is untrusted.

## Testing
- Full suite **431 green / 44 suites**; `tsc` 159 (no new).

Pure JS — OTA-deliverable (and hot-reloads in the local dev build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)