### PR TITLE
fix(saved): Favorites/Blocked white backgrounds (Themed View)

### DIFF
--- a/screens/BlockedScreen.tsx
+++ b/screens/BlockedScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from 'react';
-import { StyleSheet, ScrollView, Text, FlatList, TextInput, Pressable } from 'react-native';
+import { StyleSheet, ScrollView, Text, FlatList, TextInput, Pressable, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
-import { View } from '../components/Themed';
 import FavoriteCard from '../components/shared/FavoriteCard';
 import AppStyles from '../AppStyles';
 import { supperClub } from '../theme/supperClub';

--- a/screens/FavoritesScreen.tsx
+++ b/screens/FavoritesScreen.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useMemo } from 'react';
-import { StyleSheet, ScrollView, Text, FlatList, TextInput, Pressable } from 'react-native';
+import { StyleSheet, ScrollView, Text, FlatList, TextInput, Pressable, View } from 'react-native';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
-import { View } from '../components/Themed';
 import FavoriteCard from '../components/shared/FavoriteCard';
 import AppStyles from '../AppStyles';
 import { supperClub } from '../theme/supperClub';


### PR DESCRIPTION
## Root cause (confirmed from a device screenshot)
Favorites and Blocked showed **giant white blocks** (empty-state area + title box). They imported `View` from `components/Themed`, whose `View` injects:
```
backgroundColor: useThemeColor({...}, 'background')  // white in a light color scheme
```
on every `<View>` without an explicit background. The empty-state and title containers (no bg in their styles) rendered **white** over the espresso `SafeAreaView`, and the white title box also hid the (white) title text.

`HistoryScreen` never used the Themed `View` — exactly why it looked correct.

## Fix
Import the plain **react-native `View`** in both screens. Backgrounds now come only from the Supper Club styles / the espresso `SafeAreaView` (which shows through the transparent empty state).

## Testing
- Full suite **431 green / 44 suites**; `tsc` 159 (no new).
- Device verify.

Pure JS — hot-reloads locally and OTA-deliverable.

## Note
`NotFoundScreen` and a legacy `ResultsShowScreen` also use the Themed `View`, but they're edge/error screens, not part of this report — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)