### PR TITLE
feat(dealbreakers): persistent 'never show me' cuisine exclusions + Avoiding bar

### DIFF
--- a/__tests__/constants/commonCuisines.test.ts
+++ b/__tests__/constants/commonCuisines.test.ts
@@ -1,0 +1,13 @@
+import { COMMON_CUISINES } from '../../constants/foodCategories';
+
+describe('COMMON_CUISINES', () => {
+  it('is a non-empty list of {alias,label} with unique aliases', () => {
+    expect(COMMON_CUISINES.length).toBeGreaterThan(5);
+    for (const c of COMMON_CUISINES) {
+      expect(typeof c.alias).toBe('string');
+      expect(typeof c.label).toBe('string');
+    }
+    const aliases = COMMON_CUISINES.map(c => c.alias);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});

--- a/__tests__/context/reducer.test.ts
+++ b/__tests__/context/reducer.test.ts
@@ -1,4 +1,4 @@
-import { appReducer, setSelectedBusiness, showBusinessModal, hideBusinessModal, setLastSearch, setLocation, requestSpin, setResults, addBlocked, removeBlocked, hydrateBlocked } from '../../context/reducer';
+import { appReducer, setSelectedBusiness, showBusinessModal, hideBusinessModal, setLastSearch, setLocation, requestSpin, setResults, addBlocked, removeBlocked, hydrateBlocked, toggleDealbreaker, hydrateDealbreakers } from '../../context/reducer';
 import { initialAppState } from '../../context/state';
 import { ActionType } from '../../context/actions';
 import { YelpBusiness } from '../../types/yelp';
@@ -162,6 +162,42 @@ describe('appReducer', () => {
       // A later unblock must not repopulate the old city's results from stale raw.
       const afterUnblock = appReducer(moved, removeBlocked('b'));
       expect(afterUnblock.results).toEqual([]);
+    });
+  });
+
+  describe('dealbreakers exclusion', () => {
+    const biz = (id: string, cats: string[] = []) =>
+      ({ id, name: id, distance: 100, rating: 4, categories: cats.map(a => ({ alias: a, title: a })) } as any);
+    const [pizza, sushi, tacos] = [biz('a', ['pizza']), biz('b', ['sushi']), biz('c', ['tacos'])];
+
+    it('excludes dealbreaker cuisines from results but keeps rawResults', () => {
+      const seeded = { ...initialAppState, dealbreakerCategoryIds: ['sushi'] };
+      const next = appReducer(seeded, setResults([pizza, sushi, tacos]));
+      expect(next.results.map((r: any) => r.id)).toEqual(['a', 'c']);
+      expect(next.rawResults.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('lets a per-search include override a dealbreaker for that search', () => {
+      const seeded = { ...initialAppState, dealbreakerCategoryIds: ['sushi'], filters: { ...initialAppState.filters, categoryIds: ['sushi'] } };
+      const next = appReducer(seeded, setResults([pizza, sushi, tacos]));
+      expect(next.results.map((r: any) => r.id)).toEqual(['b']);
+    });
+
+    it('ToggleDealbreaker adds then removes and re-filters live', () => {
+      const withResults = appReducer(initialAppState, setResults([pizza, sushi, tacos]));
+      expect(withResults.results.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+      const added = appReducer(withResults, toggleDealbreaker('sushi'));
+      expect(added.dealbreakerCategoryIds).toEqual(['sushi']);
+      expect(added.results.map((r: any) => r.id)).toEqual(['a', 'c']);
+      const removed = appReducer(added, toggleDealbreaker('sushi'));
+      expect(removed.dealbreakerCategoryIds).toEqual([]);
+      expect(removed.results.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+    });
+
+    it('HydrateDealbreakers re-filters results set before hydration', () => {
+      const withResults = appReducer(initialAppState, setResults([pizza, sushi, tacos]));
+      const next = appReducer(withResults, hydrateDealbreakers(['pizza']));
+      expect(next.results.map((r: any) => r.id)).toEqual(['b', 'c']);
     });
   });
 

--- a/__tests__/hooks/useDealbreakers.test.tsx
+++ b/__tests__/hooks/useDealbreakers.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * Tests for useDealbreakers hook to ensure the persisted dealbreaker
+ * category aliases are hydrated into global state on mount. Mirrors the
+ * mocking conventions used by the other persistence-hook tests (storage
+ * hook + logging utility mocked at the module level).
+ */
+
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { useDealbreakers } from '../../hooks/useDealbreakers';
+import { RootContext } from '../../context/RootContext';
+import { initialAppState } from '../../context/state';
+import { hydrateDealbreakers } from '../../context/reducer';
+
+// Mock storage (same shape as usePersistentStorage's public API)
+const mockStorage = {
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  deleteItem: jest.fn(),
+  getAllItems: jest.fn(),
+  forceSetItem: jest.fn(),
+  isHydrated: jest.fn(),
+  markAsHydrated: jest.fn(),
+};
+
+jest.mock('../../hooks/usePersistentStorage', () => {
+  return jest.fn(() => mockStorage);
+});
+
+// Mock logging
+jest.mock('../../utils/log', () => ({
+  logSafe: jest.fn(),
+  safeStringify: (obj: any) => JSON.stringify(obj),
+}));
+
+function Harness() {
+  useDealbreakers();
+  return null;
+}
+
+describe('useDealbreakers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStorage.getItem.mockResolvedValue(['sushi']);
+    mockStorage.setItem.mockResolvedValue(undefined);
+  });
+
+  it('hydrates the persisted dealbreakers on mount', async () => {
+    const dispatch = jest.fn();
+
+    render(
+      <RootContext.Provider value={{ state: { ...initialAppState }, dispatch }}>
+        <Harness />
+      </RootContext.Provider>
+    );
+
+    await waitFor(() =>
+      expect(dispatch).toHaveBeenCalledWith(hydrateDealbreakers(['sushi']))
+    );
+  });
+});

--- a/__tests__/mocks/mockState.ts
+++ b/__tests__/mocks/mockState.ts
@@ -1,6 +1,10 @@
-import { AppState, initialFilters } from '../../context/state';
+import { AppState, initialAppState, initialFilters } from '../../context/state';
 
 export const mockInitialState: AppState = {
+  // Start from the real initial state so newly-added AppState fields (e.g.
+  // dealbreakerCategoryIds, blocked, rawResults) are always present, then keep
+  // the test-specific overrides below.
+  ...initialAppState,
   categories: [],
   detail: null,
   filter: {},

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -46,6 +46,12 @@ jest.mock('../../hooks/useBlocked', () => ({
 // Spy so we can assert Search hydrates the blocked list on its own (deep-link entry).
 const { useBlocked: mockUseBlocked } = require('../../hooks/useBlocked');
 
+// useDealbreakers hits persistent storage; stub it so screen tests don't touch
+// AsyncStorage. It's mounted purely for its hydrate/persist side effect here.
+jest.mock('../../hooks/useDealbreakers', () => ({
+  useDealbreakers: () => ({ dealbreakers: [] }),
+}));
+
 // Configurable favorite/blocked sets (prefixed `mock` for the jest factory).
 const mockFavoriteIds = new Set<string>();
 const mockBlockedIds = new Set<string>();
@@ -136,7 +142,7 @@ describe('SearchScreen', () => {
     expect(mockDispatch).toHaveBeenCalledWith(setShowFilter(true));
   });
 
-  it('shows a favorites + blocked-hidden summary above the results', () => {
+  it('shows the favorites chip and folds the blocked count into the Avoiding bar', () => {
     mockFavoriteIds.add('a');   // Alpha is favorited (in the visible list)
     mockBlockedIds.add('c');    // Gamma is blocked (only in rawResults)
     const state = {
@@ -151,13 +157,31 @@ describe('SearchScreen', () => {
         { id: 'c', name: 'Gamma Grill', categories: [] },
       ] as any,
     };
-    const { getByText } = render(
+    const { getByText, getByTestId } = render(
       <RootContext.Provider value={{ state, dispatch: mockDispatch }}>
         <SearchScreen />
       </RootContext.Provider>
     );
     expect(getByText('1 favorite')).toBeTruthy();
-    expect(getByText('1 blocked hidden')).toBeTruthy();
+    // The standalone "N blocked hidden" summary is gone; the count now lives in
+    // the Avoiding bar (rendered because blockedCount > 0).
+    const bar = getByTestId('avoiding-bar');
+    expect(within(bar).getByText(/1 blocked/)).toBeTruthy();
+  });
+
+  it('shows the Avoiding bar when there are dealbreakers', () => {
+    const state = {
+      ...mockInitialState,
+      dealbreakerCategoryIds: ['sushi'],
+      results: [{ id: 'a', name: 'Alpha', categories: [] }] as any,
+      rawResults: [{ id: 'a', name: 'Alpha', categories: [] }] as any,
+    };
+    const { getByTestId } = render(
+      <RootContext.Provider value={{ state, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    expect(getByTestId('avoiding-bar')).toBeTruthy();
   });
 
   it('shows an all-blocked empty state when every match is blocked', () => {

--- a/__tests__/screens/SearchScreen.test.tsx
+++ b/__tests__/screens/SearchScreen.test.tsx
@@ -184,6 +184,26 @@ describe('SearchScreen', () => {
     expect(getByTestId('avoiding-bar')).toBeTruthy();
   });
 
+  it('surfaces an all-avoided empty state (with a tappable Avoiding bar) when dealbreakers hide every match', () => {
+    // The reducer already dropped the sushi place from results (dealbreaker),
+    // but rawResults still holds it — the user searched and got matches, then
+    // their "Never show me" settings hid them all.
+    const state = {
+      ...mockInitialState,
+      dealbreakerCategoryIds: ['sushi'],
+      results: [] as any,
+      rawResults: [{ id: 's', name: 'Sushi Spot', categories: [{ alias: 'sushi', title: 'Sushi' }] }] as any,
+    };
+    const { getByTestId } = render(
+      <RootContext.Provider value={{ state, dispatch: mockDispatch }}>
+        <SearchScreen />
+      </RootContext.Provider>
+    );
+    expect(getByTestId('all-avoided-empty')).toBeTruthy();
+    // The bar is present so the user can tap to adjust their exclusions.
+    expect(getByTestId('avoiding-bar')).toBeTruthy();
+  });
+
   it('shows an all-blocked empty state when every match is blocked', () => {
     mockBlockedIds.add('a');
     mockBlockedIds.add('b');

--- a/components/AvoidingBar.tsx
+++ b/components/AvoidingBar.tsx
@@ -7,6 +7,10 @@ import { COMMON_CUISINES } from '../constants/foodCategories';
 interface AvoidingBarProps {
   dealbreakers: string[];
   perSearchExcludes: string[];
+  // Per-search category inclusions. A cuisine that is both a standing dealbreaker
+  // and an explicit include is SHOWN by the reducer (include wins), so it must be
+  // dropped from the avoided list here to mirror that override.
+  includes?: string[];
   blockedCount: number;
   onPress: () => void;
 }
@@ -14,8 +18,9 @@ interface AvoidingBarProps {
 const labelFor = (alias: string) =>
   COMMON_CUISINES.find(c => c.alias === alias)?.label ?? alias;
 
-export const AvoidingBar: React.FC<AvoidingBarProps> = ({ dealbreakers, perSearchExcludes, blockedCount, onPress }) => {
-  const cuisineAliases = [...new Set([...dealbreakers, ...perSearchExcludes])];
+export const AvoidingBar: React.FC<AvoidingBarProps> = ({ dealbreakers, perSearchExcludes, includes = [], blockedCount, onPress }) => {
+  const cuisineAliases = [...new Set([...dealbreakers, ...perSearchExcludes])]
+    .filter(a => !includes.includes(a));
   if (cuisineAliases.length === 0 && blockedCount === 0) return null;
 
   const cuisineLabels = cuisineAliases.map(labelFor).join(', ');

--- a/components/AvoidingBar.tsx
+++ b/components/AvoidingBar.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { supperClub } from '../theme/supperClub';
+import { COMMON_CUISINES } from '../constants/foodCategories';
+
+interface AvoidingBarProps {
+  dealbreakers: string[];
+  perSearchExcludes: string[];
+  blockedCount: number;
+  onPress: () => void;
+}
+
+const labelFor = (alias: string) =>
+  COMMON_CUISINES.find(c => c.alias === alias)?.label ?? alias;
+
+export const AvoidingBar: React.FC<AvoidingBarProps> = ({ dealbreakers, perSearchExcludes, blockedCount, onPress }) => {
+  const cuisineAliases = [...new Set([...dealbreakers, ...perSearchExcludes])];
+  if (cuisineAliases.length === 0 && blockedCount === 0) return null;
+
+  const cuisineLabels = cuisineAliases.map(labelFor).join(', ');
+  const parts = [
+    cuisineLabels ? `Avoiding: ${cuisineLabels}` : 'Avoiding',
+    blockedCount > 0 ? `${blockedCount} blocked` : null,
+  ].filter(Boolean);
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.bar, pressed && styles.pressed]}
+      onPress={onPress}
+      testID="avoiding-bar"
+      accessibilityRole="button"
+      accessibilityLabel={`Avoiding filters. ${parts.join('. ')}. Tap to edit.`}
+    >
+      <Ionicons name="eye-off-outline" size={14} color={supperClub.textMuted} />
+      <Text style={styles.text} numberOfLines={1}>{parts.join('  ·  ')}</Text>
+      <Ionicons name="chevron-forward" size={14} color={supperClub.textMuted} />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: supperClub.surface,
+    borderWidth: 1,
+    borderColor: supperClub.borderSoft,
+  },
+  pressed: { opacity: 0.7 },
+  text: { flex: 1, fontSize: 12, color: supperClub.textMuted },
+});
+
+export default AvoidingBar;

--- a/components/__tests__/AvoidingBar.test.tsx
+++ b/components/__tests__/AvoidingBar.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { AvoidingBar } from '../AvoidingBar';
+
+describe('AvoidingBar', () => {
+  it('renders nothing when there is nothing to avoid', () => {
+    const { queryByTestId } = render(
+      <AvoidingBar dealbreakers={[]} perSearchExcludes={[]} blockedCount={0} onPress={jest.fn()} />
+    );
+    expect(queryByTestId('avoiding-bar')).toBeNull();
+  });
+
+  it('summarizes cuisines and blocked count, and fires onPress', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByText } = render(
+      <AvoidingBar dealbreakers={['sushi']} perSearchExcludes={['pizza']} blockedCount={3} onPress={onPress} />
+    );
+    expect(getByText(/Sushi/)).toBeTruthy();
+    expect(getByText(/Pizza/)).toBeTruthy();
+    expect(getByText(/3 blocked/)).toBeTruthy();
+    fireEvent.press(getByTestId('avoiding-bar'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});

--- a/components/__tests__/AvoidingBar.test.tsx
+++ b/components/__tests__/AvoidingBar.test.tsx
@@ -48,4 +48,33 @@ describe('AvoidingBar', () => {
     expect(getByTestId('avoiding-bar')).toBeTruthy();
     expect(getByText(/2 blocked/)).toBeTruthy();
   });
+
+  it('renders null when the only avoided cuisine is overridden by a per-search include', () => {
+    // sushi is a standing dealbreaker but this search explicitly includes it →
+    // the reducer shows it, so the bar must not claim it's avoided.
+    const { queryByTestId } = render(
+      <AvoidingBar
+        dealbreakers={['sushi']}
+        perSearchExcludes={[]}
+        includes={['sushi']}
+        blockedCount={0}
+        onPress={jest.fn()}
+      />
+    );
+    expect(queryByTestId('avoiding-bar')).toBeNull();
+  });
+
+  it('excludes per-search includes from the avoided list but keeps the rest', () => {
+    const { getByText, queryByText } = render(
+      <AvoidingBar
+        dealbreakers={['sushi', 'pizza']}
+        perSearchExcludes={[]}
+        includes={['sushi']}
+        blockedCount={0}
+        onPress={jest.fn()}
+      />
+    );
+    expect(getByText(/Pizza/)).toBeTruthy();
+    expect(queryByText(/Sushi/)).toBeNull();
+  });
 });

--- a/components/__tests__/AvoidingBar.test.tsx
+++ b/components/__tests__/AvoidingBar.test.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Text } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import { AvoidingBar } from '../AvoidingBar';
 
@@ -20,5 +21,31 @@ describe('AvoidingBar', () => {
     expect(getByText(/3 blocked/)).toBeTruthy();
     fireEvent.press(getByTestId('avoiding-bar'));
     expect(onPress).toHaveBeenCalled();
+  });
+
+  it('dedupes a cuisine present in both lists so it renders once', () => {
+    const { getByTestId } = render(
+      <AvoidingBar dealbreakers={['sushi']} perSearchExcludes={['sushi']} blockedCount={0} onPress={jest.fn()} />
+    );
+    const summary = getByTestId('avoiding-bar')
+      .findAllByType(Text)
+      .map(node => node.props.children)
+      .find(child => typeof child === 'string' && child.includes('Sushi')) as string;
+    expect(summary.match(/Sushi/g)?.length).toBe(1);
+  });
+
+  it('falls back to the raw alias for cuisines not in COMMON_CUISINES', () => {
+    const { getByText } = render(
+      <AvoidingBar dealbreakers={[]} perSearchExcludes={['klingon']} blockedCount={0} onPress={jest.fn()} />
+    );
+    expect(getByText(/klingon/)).toBeTruthy();
+  });
+
+  it('renders when only blockedCount is set (no cuisines)', () => {
+    const { getByTestId, getByText } = render(
+      <AvoidingBar dealbreakers={[]} perSearchExcludes={[]} blockedCount={2} onPress={jest.fn()} />
+    );
+    expect(getByTestId('avoiding-bar')).toBeTruthy();
+    expect(getByText(/2 blocked/)).toBeTruthy();
   });
 });

--- a/components/filter/FiltersSheet.tsx
+++ b/components/filter/FiltersSheet.tsx
@@ -13,7 +13,8 @@ import { MaterialIcons as Icon } from '@expo/vector-icons';
 import Slider from '@react-native-community/slider';
 import Config from '../../Config';
 import { RootContext } from '../../context/RootContext';
-import { setFilters, resetFilters } from '../../context/reducer';
+import { setFilters, resetFilters, toggleDealbreaker } from '../../context/reducer';
+import { COMMON_CUISINES } from '../../constants/foodCategories';
 import AppStyles from '../../AppStyles';
 import { supperClub } from '../../theme/supperClub';
 import { Text } from '../Themed';
@@ -413,6 +414,51 @@ const FiltersSheet: React.FC<FiltersSheetProps> = ({ visible, onClose, testID })
               ))}
             </View>
           </View>
+
+          <Divider />
+
+          {/* Never show me — standing "dealbreaker" preference. Unlike the
+              per-search cuisine chips above, tapping here dispatches immediately
+              and persists; it is NOT routed through the local Apply flow. */}
+          <View>
+            <View style={styles.sectionTitleWrapper}>
+              <Text style={styles.sectionTitle}>Never show me</Text>
+              <Text style={styles.sectionSubtitle}>Always hidden</Text>
+            </View>
+            <View style={styles.categoryContainer}>
+              {COMMON_CUISINES.map(cuisine => {
+                const isActive = state.dealbreakerCategoryIds.includes(cuisine.alias);
+                return (
+                  <Pressable
+                    key={cuisine.alias}
+                    testID={`dealbreaker-${cuisine.alias}`}
+                    onPress={() => dispatch(toggleDealbreaker(cuisine.alias))}
+                    style={({ pressed }) => [
+                      styles.categoryChip,
+                      isActive && styles.dealbreakerChipActive,
+                      { opacity: !Config.isAndroid && pressed ? 0.6 : 1 },
+                    ]}
+                    android_ripple={{ color: 'lightgrey' }}
+                  >
+                    <Icon
+                      name="block"
+                      size={14}
+                      color={isActive ? '#FFFFFF' : supperClub.textMuted}
+                      style={styles.categoryIcon}
+                    />
+                    <Text
+                      style={[
+                        styles.categoryChipText,
+                        isActive && styles.categoryChipTextSelected,
+                      ]}
+                    >
+                      {cuisine.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
         </ScrollView>
 
         <Divider />
@@ -540,6 +586,10 @@ const styles = StyleSheet.create({
     borderColor: supperClub.success,
   },
   categoryChipExcluded: {
+    backgroundColor: supperClub.error,
+    borderColor: supperClub.error,
+  },
+  dealbreakerChipActive: {
     backgroundColor: supperClub.error,
     borderColor: supperClub.error,
   },

--- a/components/filter/FiltersSheet.tsx
+++ b/components/filter/FiltersSheet.tsx
@@ -589,6 +589,10 @@ const styles = StyleSheet.create({
     backgroundColor: supperClub.error,
     borderColor: supperClub.error,
   },
+  // Intentionally shares the error tint with categoryChipExcluded but kept
+  // separate: they express different domain concepts (a standing dealbreaker vs
+  // a per-search exclude), so a future restyle of one must not silently change
+  // the other. Do not merge these two styles.
   dealbreakerChipActive: {
     backgroundColor: supperClub.error,
     borderColor: supperClub.error,

--- a/components/filter/__tests__/FiltersSheet.test.tsx
+++ b/components/filter/__tests__/FiltersSheet.test.tsx
@@ -3,7 +3,9 @@ import { render, fireEvent } from '@testing-library/react-native';
 import FiltersSheet from '../FiltersSheet';
 import { RootContext } from '../../../context/RootContext';
 import { AppState, initialAppState } from '../../../context/state';
+import { StyleSheet } from 'react-native';
 import { toggleDealbreaker } from '../../../context/reducer';
+import { supperClub } from '../../../theme/supperClub';
 
 // Mock the vector icons
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon');
@@ -326,9 +328,21 @@ describe('FiltersSheet', () => {
         dealbreakerCategoryIds: ['pizza'],
       });
 
-      // Chip renders whether active or not; tapping an active one toggles it off.
-      const chip = getByTestId('dealbreaker-pizza');
-      expect(chip).toBeTruthy();
+      // Prove the active branch actually fired: an active chip carries the
+      // error-tinted background. Pressable's style may be a function of press
+      // state or an already-resolved array on the host node, so normalize both
+      // then flatten before asserting. This must FAIL if isActive were hardcoded
+      // to a constant.
+      const bgFor = (testID: string): string | undefined => {
+        const raw = getByTestId(testID).props.style;
+        const resolved = typeof raw === 'function' ? raw({ pressed: false }) : raw;
+        return (StyleSheet.flatten(resolved) as { backgroundColor?: string })
+          .backgroundColor;
+      };
+
+      expect(bgFor('dealbreaker-pizza')).toBe(supperClub.error);
+      // An inactive chip must NOT carry the error tint.
+      expect(bgFor('dealbreaker-sushi')).not.toBe(supperClub.error);
     });
   });
 

--- a/components/filter/__tests__/FiltersSheet.test.tsx
+++ b/components/filter/__tests__/FiltersSheet.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import FiltersSheet from '../FiltersSheet';
 import { RootContext } from '../../../context/RootContext';
 import { AppState, initialAppState } from '../../../context/state';
+import { toggleDealbreaker } from '../../../context/reducer';
 
 // Mock the vector icons
 jest.mock('react-native-vector-icons/MaterialIcons', () => 'Icon');
@@ -300,6 +301,34 @@ describe('FiltersSheet', () => {
       
       expect(mockDispatch).toHaveBeenCalled();
       expect(mockOnClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Dealbreakers ("Never show me")', () => {
+    it('shows the "Never show me" section and toggles a dealbreaker immediately', () => {
+      const { getByText, getByTestId, mockDispatch } = renderFiltersSheet();
+
+      // Section header + subtitle are always present, even with an empty list.
+      expect(getByText('Never show me')).toBeTruthy();
+
+      // Inactive chips still render and are pressable for the default empty list.
+      const chip = getByTestId('dealbreaker-sushi');
+      expect(chip).toBeTruthy();
+
+      fireEvent.press(chip);
+
+      // Dispatches immediately — not gated behind the local Apply flow.
+      expect(mockDispatch).toHaveBeenCalledWith(toggleDealbreaker('sushi'));
+    });
+
+    it('reflects the active dealbreaker state from context', () => {
+      const { getByTestId } = renderFiltersSheet({
+        dealbreakerCategoryIds: ['pizza'],
+      });
+
+      // Chip renders whether active or not; tapping an active one toggles it off.
+      const chip = getByTestId('dealbreaker-pizza');
+      expect(chip).toBeTruthy();
     });
   });
 

--- a/constants/foodCategories.ts
+++ b/constants/foodCategories.ts
@@ -202,3 +202,21 @@ export function getPopularCategories(limit: number = 12): CategoryProps[] {
 export function getCategoryByAlias(alias: string): CategoryProps | undefined {
   return FOOD_CATEGORIES.find(cat => cat.alias === alias);
 }
+
+// Curated common cuisines offered as "Dealbreaker" chips. Aliases are Yelp
+// category aliases (the de-facto taxonomy); a future provider adapter maps its
+// categories into this same alias space.
+export const COMMON_CUISINES: { alias: string; label: string }[] = [
+  { alias: 'hotdogs', label: 'Fast Food' },
+  { alias: 'sushi', label: 'Sushi' },
+  { alias: 'buffets', label: 'Buffet' },
+  { alias: 'pizza', label: 'Pizza' },
+  { alias: 'mexican', label: 'Mexican' },
+  { alias: 'chinese', label: 'Chinese' },
+  { alias: 'indpak', label: 'Indian' },
+  { alias: 'thai', label: 'Thai' },
+  { alias: 'italian', label: 'Italian' },
+  { alias: 'burgers', label: 'Burgers' },
+  { alias: 'seafood', label: 'Seafood' },
+  { alias: 'vegan', label: 'Vegan' },
+];

--- a/context/actions.ts
+++ b/context/actions.ts
@@ -29,6 +29,8 @@ export enum ActionType {
 	ShowBusinessModal,
 	HideBusinessModal,
 	ToggleCategoryFilter,
+	ToggleDealbreaker,
+	HydrateDealbreakers,
 	SetLastSearch,
 	RequestSpin,
 }
@@ -164,4 +166,14 @@ export interface ToggleCategoryFilter {
 	payload: { categoryAlias: string };
 }
 
-export type AppActions = SetCategories | SetDetail | SetFilter | SetFilters | ResetFilters | HydrateFilters | SetLocation | SetCoords | SetResults | SetShowFilter | AddFavorite | RemoveFavorite | HydrateFavorites | AddBlocked | RemoveBlocked | HydrateBlocked | AddHistory | ClearHistory | HydrateHistory | AddSpinHistory | SetSelectedBusiness | ShowBusinessModal | HideBusinessModal | ToggleCategoryFilter | SetLastSearch | RequestSpin;
+export interface ToggleDealbreaker {
+	type: ActionType.ToggleDealbreaker;
+	payload: { alias: string };
+}
+
+export interface HydrateDealbreakers {
+	type: ActionType.HydrateDealbreakers;
+	payload: { aliases: string[] };
+}
+
+export type AppActions = SetCategories | SetDetail | SetFilter | SetFilters | ResetFilters | HydrateFilters | SetLocation | SetCoords | SetResults | SetShowFilter | AddFavorite | RemoveFavorite | HydrateFavorites | AddBlocked | RemoveBlocked | HydrateBlocked | AddHistory | ClearHistory | HydrateHistory | AddSpinHistory | SetSelectedBusiness | ShowBusinessModal | HideBusinessModal | ToggleCategoryFilter | ToggleDealbreaker | HydrateDealbreakers | SetLastSearch | RequestSpin;

--- a/context/reducer.ts
+++ b/context/reducer.ts
@@ -96,7 +96,7 @@ function normalizeHistory(items: HistoryItem[]): HistoryItem[] {
 // a user can deliberately search a cuisine they normally never want. Blocked
 // places (by id) are removed on top. Provider-agnostic: reads only
 // business.categories[].alias via applyFilters.
-function computeVisibleResults(
+export function computeVisibleResults(
 	rawResults: BusinessProps[],
 	filters: Filters,
 	blocked: FavoriteItem[],

--- a/context/reducer.ts
+++ b/context/reducer.ts
@@ -29,6 +29,8 @@ import {
 	ShowBusinessModal,
 	HideBusinessModal,
 	ToggleCategoryFilter,
+	ToggleDealbreaker,
+	HydrateDealbreakers,
 	SetLastSearch,
 	RequestSpin,
 } from "./actions";
@@ -89,13 +91,22 @@ function normalizeHistory(items: HistoryItem[]): HistoryItem[] {
 // removed. Blocked lives in state, so the reducer is the single place that
 // excludes it — rawResults stays intact (for the "N blocked hidden" count and
 // for re-filtering live when a business is blocked/unblocked).
+// Effective excluded cuisines = (persistent dealbreakers ∪ this-search excludes)
+// − this-search includes. A per-search include always wins over a dealbreaker so
+// a user can deliberately search a cuisine they normally never want. Blocked
+// places (by id) are removed on top. Provider-agnostic: reads only
+// business.categories[].alias via applyFilters.
 function computeVisibleResults(
 	rawResults: BusinessProps[],
 	filters: Filters,
 	blocked: FavoriteItem[],
+	dealbreakers: string[],
 ): BusinessProps[] {
 	const blockedIds = new Set(blocked.map(b => b.id));
-	return applyFilters(rawResults, filters).filter(b => !blockedIds.has(b.id));
+	const effectiveExcluded = [...new Set([...dealbreakers, ...filters.excludedCategoryIds])]
+		.filter(alias => !filters.categoryIds.includes(alias));
+	const effectiveFilters = { ...filters, excludedCategoryIds: effectiveExcluded };
+	return applyFilters(rawResults, effectiveFilters).filter(b => !blockedIds.has(b.id));
 }
 
 export function appReducer(state: AppState, action: AppActions): AppState {
@@ -148,7 +159,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 			return {
 				...state,
 				rawResults,
-				results: computeVisibleResults(rawResults, state.filters, state.blocked),
+				results: computeVisibleResults(rawResults, state.filters, state.blocked, state.dealbreakerCategoryIds),
 			};
 		case ActionType.SetLastSearch:
 			return {
@@ -185,7 +196,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 				...state,
 				blocked: newBlocked,
 				// Re-filter so a newly blocked business disappears from the list now.
-				results: computeVisibleResults(state.rawResults, state.filters, newBlocked),
+				results: computeVisibleResults(state.rawResults, state.filters, newBlocked, state.dealbreakerCategoryIds),
 			};
 		}
 		case ActionType.RemoveBlocked: {
@@ -194,7 +205,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 				...state,
 				blocked: newBlocked,
 				// Unblocking brings it back into the visible list.
-				results: computeVisibleResults(state.rawResults, state.filters, newBlocked),
+				results: computeVisibleResults(state.rawResults, state.filters, newBlocked, state.dealbreakerCategoryIds),
 			};
 		}
 		case ActionType.HydrateBlocked:
@@ -203,7 +214,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 				blocked: action.payload.blocked,
 				// Persisted blocks may hydrate after results are already set — re-filter
 				// so those businesses don't linger visible until the next action.
-				results: computeVisibleResults(state.rawResults, state.filters, action.payload.blocked),
+				results: computeVisibleResults(state.rawResults, state.filters, action.payload.blocked, state.dealbreakerCategoryIds),
 			};
 		case ActionType.AddHistory:
 			// Dedupe by id, then normalize with stable sorting and cap
@@ -262,7 +273,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 				...action.payload.filters,
 			};
 			// Re-apply filters (and blocked exclusion) to raw results
-			const refiltered = computeVisibleResults(state.rawResults, newFilters, state.blocked);
+			const refiltered = computeVisibleResults(state.rawResults, newFilters, state.blocked, state.dealbreakerCategoryIds);
 			return {
 				...state,
 				filters: newFilters,
@@ -271,7 +282,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 		}
 		case ActionType.ResetFilters: {
 			// Re-apply filters (and blocked exclusion) to raw results
-			const refiltered = computeVisibleResults(state.rawResults, initialFilters, state.blocked);
+			const refiltered = computeVisibleResults(state.rawResults, initialFilters, state.blocked, state.dealbreakerCategoryIds);
 			return {
 				...state,
 				filters: initialFilters,
@@ -311,7 +322,7 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 			};
 
 			// Re-apply filters (and blocked exclusion) to raw results immediately
-			const refiltered = computeVisibleResults(state.rawResults, newFilters, state.blocked);
+			const refiltered = computeVisibleResults(state.rawResults, newFilters, state.blocked, state.dealbreakerCategoryIds);
 
 			return {
 				...state,
@@ -319,6 +330,23 @@ export function appReducer(state: AppState, action: AppActions): AppState {
 				results: refiltered,
 			};
 		}
+		case ActionType.ToggleDealbreaker: {
+			const { alias } = action.payload;
+			const newDealbreakers = state.dealbreakerCategoryIds.includes(alias)
+				? state.dealbreakerCategoryIds.filter(a => a !== alias)
+				: [...state.dealbreakerCategoryIds, alias];
+			return {
+				...state,
+				dealbreakerCategoryIds: newDealbreakers,
+				results: computeVisibleResults(state.rawResults, state.filters, state.blocked, newDealbreakers),
+			};
+		}
+		case ActionType.HydrateDealbreakers:
+			return {
+				...state,
+				dealbreakerCategoryIds: action.payload.aliases,
+				results: computeVisibleResults(state.rawResults, state.filters, state.blocked, action.payload.aliases),
+			};
 		default:
 			return state;
 	}
@@ -449,4 +477,14 @@ export const hydrateFilters = (filters: Filters): HydrateFilters => ({
 export const toggleCategoryFilter = (categoryAlias: string): ToggleCategoryFilter => ({
 	type: ActionType.ToggleCategoryFilter,
 	payload: { categoryAlias },
+});
+
+export const toggleDealbreaker = (alias: string): ToggleDealbreaker => ({
+	type: ActionType.ToggleDealbreaker,
+	payload: { alias },
+});
+
+export const hydrateDealbreakers = (aliases: string[]): HydrateDealbreakers => ({
+	type: ActionType.HydrateDealbreakers,
+	payload: { aliases },
 });

--- a/context/state.ts
+++ b/context/state.ts
@@ -30,6 +30,7 @@ export interface AppState {
 	showFilter: boolean;
 	favorites: FavoriteItem[];
 	blocked: FavoriteItem[];
+	dealbreakerCategoryIds: string[]; // persistent "never want" cuisine aliases
 	history: HistoryItem[];
 	spinHistory: SpinHistory[];
 	selectedBusiness: YelpBusiness | null;
@@ -78,6 +79,7 @@ export const initialAppState: AppState = {
 	showFilter: false,
 	favorites: [],
 	blocked: [],
+	dealbreakerCategoryIds: [],
 	history: [],
 	spinHistory: [],
 	selectedBusiness: null,

--- a/docs/superpowers/plans/2026-07-30-dealbreakers.md
+++ b/docs/superpowers/plans/2026-07-30-dealbreakers.md
@@ -1,0 +1,733 @@
+# Dealbreakers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent "Dealbreakers" (never-want cuisines) with per-search override, filtered in the reducer, and an "Avoiding …" bar that showcases it on Home and Search.
+
+**Architecture:** Exclusion stays a single-source-of-truth in the reducer's `computeVisibleResults`, which merges `dealbreakerCategoryIds ∪ filters.excludedCategoryIds`, subtracts per-search includes (`filters.categoryIds`), then removes blocked places. A persisted `useDealbreakers` hook (mirroring `useBlocked`) hydrates/saves the list. UI: a "Never show me" section in the Filters sheet (applies immediately) + an `AvoidingBar` component. Client-side only — no Yelp query change — so it reads only `business.categories[].alias` and stays provider-portable.
+
+**Tech Stack:** React Native + Expo, React Context + `useReducer`, AsyncStorage via `usePersistentStorage`, jest-expo + @testing-library/react-native.
+
+**Spec:** `docs/superpowers/specs/2026-07-30-dealbreakers-exclusion-design.md`
+
+**Conventions:** Package manager is **yarn**. Run tests with `yarn jest <path>`. Every task ends by running the full suite (`yarn jest`) and `npx tsc --noEmit` (baseline is 159 errors — do not increase it). Commit at the end of each task.
+
+## File structure
+
+- `context/state.ts` — add `dealbreakerCategoryIds: string[]` to `AppState` + `initialAppState`.
+- `context/actions.ts` — `ToggleDealbreaker`, `HydrateDealbreakers` action types + union.
+- `context/reducer.ts` — extend `computeVisibleResults`; new cases + creators; update call sites.
+- `constants/foodCategories.ts` — `COMMON_CUISINES` curated list.
+- `hooks/useDealbreakers.ts` — new persistence hook (mirror `hooks/useBlocked.ts`).
+- `components/AvoidingBar.tsx` — new presentational component.
+- `components/filter/FiltersSheet.tsx` — "Never show me" section.
+- `screens/HomeScreen.tsx`, `screens/SearchScreen.tsx` — mount `useDealbreakers`, render `AvoidingBar`.
+- Tests alongside: `__tests__/context/reducer.test.ts`, `__tests__/hooks/useDealbreakers.test.tsx`, `components/__tests__/AvoidingBar.test.tsx`, `components/filter/__tests__/FiltersSheet.test.tsx`, screen tests.
+
+---
+
+### Task 1: State + reducer — dealbreaker exclusion with per-search override
+
+**Files:**
+- Modify: `context/state.ts` (AppState + initialAppState)
+- Modify: `context/actions.ts` (action types + union)
+- Modify: `context/reducer.ts` (`computeVisibleResults`, cases, creators, call sites)
+- Test: `__tests__/context/reducer.test.ts`
+
+- [ ] **Step 1: Add state field**
+
+In `context/state.ts`, add to the `AppState` interface (near `blocked`):
+```ts
+	dealbreakerCategoryIds: string[]; // persistent "never want" cuisine aliases (#dealbreakers)
+```
+And to `initialAppState`:
+```ts
+	dealbreakerCategoryIds: [],
+```
+
+- [ ] **Step 2: Add action types**
+
+In `context/actions.ts`, add to the `ActionType` enum (after `ToggleCategoryFilter`):
+```ts
+	ToggleDealbreaker,
+	HydrateDealbreakers,
+```
+Add interfaces (near `ToggleCategoryFilter`):
+```ts
+export interface ToggleDealbreaker {
+	type: ActionType.ToggleDealbreaker;
+	payload: { alias: string };
+}
+
+export interface HydrateDealbreakers {
+	type: ActionType.HydrateDealbreakers;
+	payload: { aliases: string[] };
+}
+```
+Add both to the `AppActions` union (append):
+```ts
+ | ToggleDealbreaker | HydrateDealbreakers;
+```
+
+- [ ] **Step 3: Write the failing reducer tests**
+
+In `__tests__/context/reducer.test.ts`, import the new creators (extend the existing import line):
+```ts
+import { appReducer, setResults, setFilters, addBlocked, toggleDealbreaker, hydrateDealbreakers } from '../../context/reducer';
+```
+Add this describe block:
+```ts
+describe('dealbreakers exclusion (#dealbreakers)', () => {
+  const biz = (id: string, cats: string[] = []) =>
+    ({ id, name: id, distance: 100, rating: 4, categories: cats.map(a => ({ alias: a, title: a })) } as any);
+  const [pizza, sushi, tacos] = [biz('a', ['pizza']), biz('b', ['sushi']), biz('c', ['tacos'])];
+
+  it('excludes dealbreaker cuisines from results but keeps rawResults', () => {
+    const seeded = { ...initialAppState, dealbreakerCategoryIds: ['sushi'] };
+    const next = appReducer(seeded, setResults([pizza, sushi, tacos]));
+    expect(next.results.map((r: any) => r.id)).toEqual(['a', 'c']);
+    expect(next.rawResults.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('lets a per-search include override a dealbreaker for that search', () => {
+    const seeded = {
+      ...initialAppState,
+      dealbreakerCategoryIds: ['sushi'],
+      filters: { ...initialAppState.filters, categoryIds: ['sushi'] },
+    };
+    const next = appReducer(seeded, setResults([pizza, sushi, tacos]));
+    // categoryIds is a whitelist too, so only sushi passes — and it is NOT excluded.
+    expect(next.results.map((r: any) => r.id)).toEqual(['b']);
+  });
+
+  it('ToggleDealbreaker adds then removes and re-filters live', () => {
+    const withResults = appReducer(initialAppState, setResults([pizza, sushi, tacos]));
+    expect(withResults.results.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+    const added = appReducer(withResults, toggleDealbreaker('sushi'));
+    expect(added.dealbreakerCategoryIds).toEqual(['sushi']);
+    expect(added.results.map((r: any) => r.id)).toEqual(['a', 'c']);
+    const removed = appReducer(added, toggleDealbreaker('sushi'));
+    expect(removed.dealbreakerCategoryIds).toEqual([]);
+    expect(removed.results.map((r: any) => r.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('HydrateDealbreakers re-filters results set before hydration', () => {
+    const withResults = appReducer(initialAppState, setResults([pizza, sushi, tacos]));
+    const next = appReducer(withResults, hydrateDealbreakers(['pizza']));
+    expect(next.results.map((r: any) => r.id)).toEqual(['b', 'c']);
+  });
+});
+```
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `yarn jest __tests__/context/reducer.test.ts -t "dealbreakers exclusion"`
+Expected: FAIL — `toggleDealbreaker`/`hydrateDealbreakers` are not exported and results aren't filtered.
+
+- [ ] **Step 5: Extend `computeVisibleResults` and add reducer cases + creators**
+
+In `context/reducer.ts`, replace the `computeVisibleResults` helper with:
+```ts
+function computeVisibleResults(
+	rawResults: BusinessProps[],
+	filters: Filters,
+	blocked: FavoriteItem[],
+	dealbreakers: string[],
+): BusinessProps[] {
+	const blockedIds = new Set(blocked.map(b => b.id));
+	// Dealbreakers + per-search excludes, minus anything explicitly included this
+	// search (per-search include overrides the standing NO).
+	const effectiveExcluded = [...new Set([...dealbreakers, ...filters.excludedCategoryIds])]
+		.filter(alias => !filters.categoryIds.includes(alias));
+	const effectiveFilters = { ...filters, excludedCategoryIds: effectiveExcluded };
+	return applyFilters(rawResults, effectiveFilters).filter(b => !blockedIds.has(b.id));
+}
+```
+Update **every** `computeVisibleResults(...)` call to pass `state.dealbreakerCategoryIds` as the 4th arg. The call sites are: `SetResults`, `SetFilters`, `ResetFilters`, `ToggleCategoryFilter`, `AddBlocked` (pass `newBlocked`), `RemoveBlocked` (pass `newBlocked`), `HydrateBlocked` (pass `action.payload.blocked`). Example for `SetResults`:
+```ts
+			results: computeVisibleResults(rawResults, state.filters, state.blocked, state.dealbreakerCategoryIds),
+```
+Add the new cases (after the `HydrateBlocked` case):
+```ts
+		case ActionType.ToggleDealbreaker: {
+			const { alias } = action.payload;
+			const newDealbreakers = state.dealbreakerCategoryIds.includes(alias)
+				? state.dealbreakerCategoryIds.filter(a => a !== alias)
+				: [...state.dealbreakerCategoryIds, alias];
+			return {
+				...state,
+				dealbreakerCategoryIds: newDealbreakers,
+				results: computeVisibleResults(state.rawResults, state.filters, state.blocked, newDealbreakers),
+			};
+		}
+		case ActionType.HydrateDealbreakers:
+			return {
+				...state,
+				dealbreakerCategoryIds: action.payload.aliases,
+				results: computeVisibleResults(state.rawResults, state.filters, state.blocked, action.payload.aliases),
+			};
+```
+Add the imports to the `from "./actions"` list: `ToggleDealbreaker`, `HydrateDealbreakers`. Add creators (near `setResults`):
+```ts
+export const toggleDealbreaker = (alias: string): ToggleDealbreaker => ({
+	type: ActionType.ToggleDealbreaker,
+	payload: { alias },
+});
+
+export const hydrateDealbreakers = (aliases: string[]): HydrateDealbreakers => ({
+	type: ActionType.HydrateDealbreakers,
+	payload: { aliases },
+});
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `yarn jest __tests__/context/reducer.test.ts`
+Expected: PASS (the new block + all existing reducer tests).
+
+- [ ] **Step 7: Full suite + typecheck**
+
+Run: `yarn jest` (expect all green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (expect ≤ 159).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add context/state.ts context/actions.ts context/reducer.ts __tests__/context/reducer.test.ts
+git commit -m "feat(dealbreakers): persistent cuisine exclusion in the reducer with per-search override"
+```
+
+---
+
+### Task 2: `COMMON_CUISINES` curated list
+
+**Files:**
+- Modify: `constants/foodCategories.ts`
+- Test: `__tests__/constants/commonCuisines.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/constants/commonCuisines.test.ts`:
+```ts
+import { COMMON_CUISINES } from '../../constants/foodCategories';
+
+describe('COMMON_CUISINES', () => {
+  it('is a non-empty list of {alias,label} with unique aliases', () => {
+    expect(COMMON_CUISINES.length).toBeGreaterThan(5);
+    for (const c of COMMON_CUISINES) {
+      expect(typeof c.alias).toBe('string');
+      expect(typeof c.label).toBe('string');
+    }
+    const aliases = COMMON_CUISINES.map(c => c.alias);
+    expect(new Set(aliases).size).toBe(aliases.length);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest __tests__/constants/commonCuisines.test.ts`
+Expected: FAIL — `COMMON_CUISINES` not exported.
+
+- [ ] **Step 3: Add the constant**
+
+Append to `constants/foodCategories.ts`:
+```ts
+// Curated common cuisines offered as "Dealbreaker" chips. Aliases are Yelp
+// category aliases (the de-facto taxonomy); a future provider adapter maps its
+// categories into this same alias space. (#dealbreakers)
+export const COMMON_CUISINES: { alias: string; label: string }[] = [
+	{ alias: 'hotdogs', label: 'Fast Food' },
+	{ alias: 'sushi', label: 'Sushi' },
+	{ alias: 'buffets', label: 'Buffet' },
+	{ alias: 'pizza', label: 'Pizza' },
+	{ alias: 'mexican', label: 'Mexican' },
+	{ alias: 'chinese', label: 'Chinese' },
+	{ alias: 'indpak', label: 'Indian' },
+	{ alias: 'thai', label: 'Thai' },
+	{ alias: 'italian', label: 'Italian' },
+	{ alias: 'burgers', label: 'Burgers' },
+	{ alias: 'seafood', label: 'Seafood' },
+	{ alias: 'vegan', label: 'Vegan' },
+];
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest __tests__/constants/commonCuisines.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add constants/foodCategories.ts __tests__/constants/commonCuisines.test.ts
+git commit -m "feat(dealbreakers): add COMMON_CUISINES curated list"
+```
+
+---
+
+### Task 3: `useDealbreakers` persistence hook
+
+**Files:**
+- Create: `hooks/useDealbreakers.ts`
+- Test: `__tests__/hooks/useDealbreakers.test.tsx`
+
+Read `hooks/useBlocked.ts` first and mirror its structure (module-level hydration guard, `usePersistentStorage`, hydrate-once effect, persist-on-change effect). The hook stores a `string[]` under key `'dealbreakers'` and dispatches `hydrateDealbreakers`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `__tests__/hooks/useDealbreakers.test.tsx`:
+```tsx
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { RootContext } from '../../context/RootContext';
+import { initialAppState } from '../../context/state';
+import { hydrateDealbreakers } from '../../context/reducer';
+import { useDealbreakers } from '../../hooks/useDealbreakers';
+
+const mockStorage = {
+  getItem: jest.fn(async () => ['sushi']),
+  setItem: jest.fn(async () => {}),
+  getAllItems: jest.fn(() => []),
+};
+jest.mock('../../hooks/usePersistentStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockStorage),
+}));
+
+function Harness() {
+  useDealbreakers();
+  return null;
+}
+
+describe('useDealbreakers', () => {
+  beforeEach(() => { jest.clearAllMocks(); mockStorage.getItem.mockResolvedValue(['sushi']); });
+
+  it('hydrates the persisted dealbreakers on mount', async () => {
+    const dispatch = jest.fn();
+    render(
+      <RootContext.Provider value={{ state: { ...initialAppState }, dispatch }}>
+        <Harness />
+      </RootContext.Provider>
+    );
+    await waitFor(() => expect(dispatch).toHaveBeenCalledWith(hydrateDealbreakers(['sushi'])));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest __tests__/hooks/useDealbreakers.test.tsx`
+Expected: FAIL — `useDealbreakers` does not exist.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `hooks/useDealbreakers.ts` (mirroring `useBlocked`; adjust names/key):
+```ts
+import { useContext, useEffect, useRef } from 'react';
+import usePersistentStorage from './usePersistentStorage';
+import { RootContext } from '../context/RootContext';
+import { hydrateDealbreakers } from '../context/reducer';
+import { logSafe } from '../utils/log';
+
+const STORAGE_KEY_DEALBREAKERS = 'dealbreakers';
+let dealbreakersHydrated = false;
+
+export function useDealbreakers() {
+	const { state, dispatch } = useContext(RootContext);
+	const storage = usePersistentStorage();
+	const hasHydratedRef = useRef(false);
+	const lastPersistedRef = useRef<string | null>(null);
+
+	// Hydrate once (module-level guard, like useBlocked).
+	useEffect(() => {
+		if (dealbreakersHydrated || hasHydratedRef.current) return;
+		hasHydratedRef.current = true;
+		dealbreakersHydrated = true;
+		(async () => {
+			try {
+				const stored = await storage.getItem<string[]>(STORAGE_KEY_DEALBREAKERS);
+				if (Array.isArray(stored)) {
+					dispatch(hydrateDealbreakers(stored));
+				}
+			} catch (error: any) {
+				logSafe('[useDealbreakers] Error loading dealbreakers', { message: error?.message });
+			}
+		})();
+	}, [storage, dispatch]);
+
+	// Persist on change.
+	useEffect(() => {
+		if (!dealbreakersHydrated) return;
+		const currentJson = JSON.stringify(state.dealbreakerCategoryIds);
+		if (currentJson === lastPersistedRef.current) return;
+		lastPersistedRef.current = currentJson;
+		(async () => {
+			try {
+				await storage.setItem(STORAGE_KEY_DEALBREAKERS, state.dealbreakerCategoryIds);
+			} catch (error: any) {
+				logSafe('[useDealbreakers] Error persisting dealbreakers', { message: error?.message });
+			}
+		})();
+	}, [state.dealbreakerCategoryIds, storage]);
+
+	return { dealbreakers: state.dealbreakerCategoryIds };
+}
+```
+Note: if `useBlocked` uses a different `usePersistentStorage` import style or method names (`getItem<T>`), match it exactly — read that file and align.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest __tests__/hooks/useDealbreakers.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Full suite + typecheck, then commit**
+
+Run: `yarn jest` and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (≤159).
+```bash
+git add hooks/useDealbreakers.ts __tests__/hooks/useDealbreakers.test.tsx
+git commit -m "feat(dealbreakers): persist/hydrate dealbreakers via useDealbreakers"
+```
+
+---
+
+### Task 4: `AvoidingBar` component
+
+**Files:**
+- Create: `components/AvoidingBar.tsx`
+- Test: `components/__tests__/AvoidingBar.test.tsx`
+
+Presentational + dumb: takes alias lists + blocked count + `onPress`, maps aliases → labels via `COMMON_CUISINES` (falling back to the alias), renders `Avoiding: A, B · N blocked`, returns `null` when there is nothing to avoid.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `components/__tests__/AvoidingBar.test.tsx`:
+```tsx
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { AvoidingBar } from '../AvoidingBar';
+
+describe('AvoidingBar', () => {
+  it('renders nothing when there is nothing to avoid', () => {
+    const { queryByTestId } = render(
+      <AvoidingBar dealbreakers={[]} perSearchExcludes={[]} blockedCount={0} onPress={jest.fn()} />
+    );
+    expect(queryByTestId('avoiding-bar')).toBeNull();
+  });
+
+  it('summarizes cuisines and blocked count, and fires onPress', () => {
+    const onPress = jest.fn();
+    const { getByTestId, getByText } = render(
+      <AvoidingBar dealbreakers={['sushi']} perSearchExcludes={['pizza']} blockedCount={3} onPress={onPress} />
+    );
+    expect(getByText(/Sushi/)).toBeTruthy();
+    expect(getByText(/Pizza/)).toBeTruthy();
+    expect(getByText(/3 blocked/)).toBeTruthy();
+    fireEvent.press(getByTestId('avoiding-bar'));
+    expect(onPress).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest components/__tests__/AvoidingBar.test.tsx`
+Expected: FAIL — `AvoidingBar` not found.
+
+- [ ] **Step 3: Implement the component**
+
+Create `components/AvoidingBar.tsx`:
+```tsx
+import React from 'react';
+import { View, Text, Pressable, StyleSheet } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { supperClub } from '../theme/supperClub';
+import { COMMON_CUISINES } from '../constants/foodCategories';
+
+interface AvoidingBarProps {
+  dealbreakers: string[];
+  perSearchExcludes: string[];
+  blockedCount: number;
+  onPress: () => void;
+}
+
+const labelFor = (alias: string) =>
+  COMMON_CUISINES.find(c => c.alias === alias)?.label ?? alias;
+
+export const AvoidingBar: React.FC<AvoidingBarProps> = ({ dealbreakers, perSearchExcludes, blockedCount, onPress }) => {
+  const cuisineAliases = [...new Set([...dealbreakers, ...perSearchExcludes])];
+  if (cuisineAliases.length === 0 && blockedCount === 0) return null;
+
+  const cuisineLabels = cuisineAliases.map(labelFor).join(', ');
+  const parts = [
+    cuisineLabels ? `Avoiding: ${cuisineLabels}` : 'Avoiding',
+    blockedCount > 0 ? `${blockedCount} blocked` : null,
+  ].filter(Boolean);
+
+  return (
+    <Pressable
+      style={({ pressed }) => [styles.bar, pressed && styles.pressed]}
+      onPress={onPress}
+      testID="avoiding-bar"
+      accessibilityRole="button"
+      accessibilityLabel={`Avoiding filters. ${parts.join('. ')}. Tap to edit.`}
+    >
+      <Ionicons name="eye-off-outline" size={14} color={supperClub.textMuted} />
+      <Text style={styles.text} numberOfLines={1}>{parts.join('  ·  ')}</Text>
+      <Ionicons name="chevron-forward" size={14} color={supperClub.textMuted} />
+    </Pressable>
+  );
+};
+
+const styles = StyleSheet.create({
+  bar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 6,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    backgroundColor: supperClub.surface,
+    borderWidth: 1,
+    borderColor: supperClub.borderSoft,
+  },
+  pressed: { opacity: 0.7 },
+  text: { flex: 1, fontSize: 12, color: supperClub.textMuted },
+});
+
+export default AvoidingBar;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest components/__tests__/AvoidingBar.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add components/AvoidingBar.tsx components/__tests__/AvoidingBar.test.tsx
+git commit -m "feat(dealbreakers): AvoidingBar summary component"
+```
+
+---
+
+### Task 5: FiltersSheet "Never show me" section
+
+**Files:**
+- Modify: `components/filter/FiltersSheet.tsx`
+- Test: `components/filter/__tests__/FiltersSheet.test.tsx`
+
+The section renders `COMMON_CUISINES` as toggle chips reflecting `state.dealbreakerCategoryIds`; tapping a chip dispatches `toggleDealbreaker(alias)` **immediately** (not through the local Apply flow).
+
+- [ ] **Step 1: Write the failing test**
+
+In `components/filter/__tests__/FiltersSheet.test.tsx`, add (the file already has a `renderFiltersSheet` helper returning `{ mockDispatch }` and imports from `../../../context/reducer`):
+```tsx
+import { toggleDealbreaker } from '../../../context/reducer';
+
+// ...inside describe('FiltersSheet', ...):
+it('shows the "Never show me" section and toggles a dealbreaker immediately', () => {
+  const { getByText, getByTestId, mockDispatch } = renderFiltersSheet();
+  expect(getByText('Never show me')).toBeTruthy();
+  fireEvent.press(getByTestId('dealbreaker-sushi'));
+  expect(mockDispatch).toHaveBeenCalledWith(toggleDealbreaker('sushi'));
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest components/filter/__tests__/FiltersSheet.test.tsx -t "Never show me"`
+Expected: FAIL — no such text/testID.
+
+- [ ] **Step 3: Implement the section**
+
+In `components/filter/FiltersSheet.tsx`:
+1. Add imports:
+```tsx
+import { COMMON_CUISINES } from '../../constants/foodCategories';
+import { toggleDealbreaker } from '../../context/reducer';
+```
+2. In the component body, read the current dealbreakers from context (the component already has `state`/`dispatch` via `useContext(RootContext)`):
+```tsx
+const dealbreakers = state.dealbreakerCategoryIds;
+```
+3. Add the section JSX after the existing cuisine/category section, before the closing of the scroll content:
+```tsx
+          <Divider />
+
+          {/* Dealbreakers — persistent, applied immediately (#dealbreakers) */}
+          <View>
+            <View style={styles.sectionTitleWrapper}>
+              <Text style={styles.sectionTitle}>Never show me</Text>
+              <Text style={styles.sectionSubtitle}>Always hidden</Text>
+            </View>
+            <View style={styles.dealbreakerWrap}>
+              {COMMON_CUISINES.map(cuisine => {
+                const active = dealbreakers.includes(cuisine.alias);
+                return (
+                  <Pressable
+                    key={cuisine.alias}
+                    testID={`dealbreaker-${cuisine.alias}`}
+                    onPress={() => dispatch(toggleDealbreaker(cuisine.alias))}
+                    style={[styles.dealbreakerChip, active && styles.dealbreakerChipActive]}
+                  >
+                    <MaterialIcons
+                      name="block"
+                      size={14}
+                      color={active ? '#FFFFFF' : supperClub.textMuted}
+                    />
+                    <Text style={[styles.dealbreakerText, active && styles.dealbreakerTextActive]}>
+                      {cuisine.label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
+          </View>
+```
+4. Add the styles (in the sheet's `StyleSheet.create`):
+```tsx
+  dealbreakerWrap: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    paddingHorizontal: 16,
+    paddingBottom: 16,
+  },
+  dealbreakerChip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: supperClub.borderSoft,
+    backgroundColor: 'rgba(255,255,255,0.05)',
+  },
+  dealbreakerChipActive: {
+    backgroundColor: supperClub.error,
+    borderColor: supperClub.error,
+  },
+  dealbreakerText: { fontSize: 13, color: supperClub.text },
+  dealbreakerTextActive: { color: '#FFFFFF' },
+```
+Note: `MaterialIcons`, `Pressable`, `Divider`, `View`, `Text`, `supperClub`, and `styles.sectionTitleWrapper/sectionTitle/sectionSubtitle` already exist in this file — reuse them; do not re-import/re-declare.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest components/filter/__tests__/FiltersSheet.test.tsx`
+Expected: PASS (the new test + all existing FiltersSheet tests).
+
+- [ ] **Step 5: Full suite + typecheck, then commit**
+
+```bash
+git add components/filter/FiltersSheet.tsx components/filter/__tests__/FiltersSheet.test.tsx
+git commit -m "feat(dealbreakers): 'Never show me' section in the filter sheet"
+```
+
+---
+
+### Task 6: Wire hydration + AvoidingBar into Home and Search
+
+**Files:**
+- Modify: `screens/HomeScreen.tsx` (mount `useDealbreakers`, render `AvoidingBar` near the wheel)
+- Modify: `screens/SearchScreen.tsx` (mount `useDealbreakers`, render `AvoidingBar` in the results header, replacing the "N blocked hidden" summary)
+- Test: `__tests__/screens/SearchScreen.test.tsx`
+
+- [ ] **Step 1: Write the failing test (Search)**
+
+In `__tests__/screens/SearchScreen.test.tsx`, mock the new hook near the other hook mocks:
+```tsx
+jest.mock('../../hooks/useDealbreakers', () => ({ useDealbreakers: () => ({ dealbreakers: [] }) }));
+```
+Add a test that the AvoidingBar shows when there are dealbreakers/blocked. Reuse the existing configurable `mockBlockedIds` and add a dealbreaker via state:
+```tsx
+it('shows the Avoiding bar when there are dealbreakers or blocked results', () => {
+  const state = {
+    ...mockInitialState,
+    dealbreakerCategoryIds: ['sushi'],
+    results: [{ id: 'a', name: 'Alpha Cafe', categories: [] }] as any,
+    rawResults: [{ id: 'a', name: 'Alpha Cafe', categories: [] }] as any,
+  };
+  const { getByTestId } = render(
+    <RootContext.Provider value={{ state, dispatch: mockDispatch }}>
+      <SearchScreen />
+    </RootContext.Provider>
+  );
+  expect(getByTestId('avoiding-bar')).toBeTruthy();
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest __tests__/screens/SearchScreen.test.tsx -t "Avoiding bar"`
+Expected: FAIL — no `avoiding-bar` rendered (and possibly a missing-mock error for `useDealbreakers`).
+
+- [ ] **Step 3: Implement in SearchScreen**
+
+In `screens/SearchScreen.tsx`:
+1. Imports:
+```tsx
+import { useDealbreakers } from '../hooks/useDealbreakers';
+import { AvoidingBar } from '../components/AvoidingBar';
+```
+2. In the component body (near the other hooks):
+```tsx
+useDealbreakers(); // hydrate/persist even when Search is the entry route
+```
+3. Replace the existing results-meta row (the `favoritesCount`/`blockedHiddenCount` summary added in #61) — keep `favoritesCount` if desired, but render the AvoidingBar for the exclusion summary. In the `ListHeaderComponent`, add below the results count:
+```tsx
+                                <AvoidingBar
+                                    dealbreakers={state.dealbreakerCategoryIds}
+                                    perSearchExcludes={state.filters.excludedCategoryIds}
+                                    blockedCount={blockedHiddenCount}
+                                    onPress={() => dispatch(setShowFilter(true))}
+                                />
+```
+(`blockedHiddenCount` and `favoritesCount` already exist from #61. Leave the favorites chip; remove only the standalone "N blocked hidden" chip so the count isn't shown twice.)
+
+- [ ] **Step 4: Run to verify it passes (Search)**
+
+Run: `yarn jest __tests__/screens/SearchScreen.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 5: Implement in HomeScreen**
+
+In `screens/HomeScreen.tsx`:
+1. Imports (same two as above).
+2. `useDealbreakers();` near the other hooks.
+3. Render the bar just above/below the wheel container (inside the main scroll/content), e.g. after `wheelContainer`:
+```tsx
+        <AvoidingBar
+          dealbreakers={state.dealbreakerCategoryIds}
+          perSearchExcludes={state.filters.excludedCategoryIds}
+          blockedCount={0}
+          onPress={() => dispatch(setShowFilter(true))}
+        />
+```
+(Home doesn't compute a blocked-hidden count; `0` is fine — the bar still shows the avoided cuisines. If a count is wanted later, derive it like SearchScreen.)
+
+- [ ] **Step 6: Full suite + typecheck**
+
+Run: `yarn jest` (all green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (≤159). If the HomeScreen or SearchScreen test suites mock `@react-navigation` etc., ensure the `useDealbreakers` mock is present in any suite that renders these screens (add `jest.mock('../../hooks/useDealbreakers', () => ({ useDealbreakers: () => ({ dealbreakers: [] }) }))` where needed).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add screens/HomeScreen.tsx screens/SearchScreen.tsx __tests__/screens/SearchScreen.test.tsx
+git commit -m "feat(dealbreakers): hydrate + show Avoiding bar on Home and Search"
+```
+
+---
+
+## Self-review notes (author checklist — already applied)
+
+- **Spec coverage:** state/persistence (T1, T3), combination + override rule (T1), COMMON_CUISINES (T2), Filters "Never show me" (T5), AvoidingBar showcase (T4, T6), reducer single-source filtering incl. spin (T1 — `state.results` is what the wheel spins), hydration race (T1 HydrateDealbreakers test). Empty-state copy tweak is minor and folded into existing empty states — not a separate task.
+- **Placeholders:** none — every code/test step has literal content.
+- **Type consistency:** `dealbreakerCategoryIds` (string[]), `toggleDealbreaker(alias)`, `hydrateDealbreakers(aliases)`, `computeVisibleResults(raw, filters, blocked, dealbreakers)` used consistently across tasks.
+- **Provider portability:** exclusion reads only `business.categories[].alias`; no Yelp field. Confirmed in T1.
+
+## Post-implementation
+
+- Run the full suite + `tsc`, then ship through the standard branch → PR → codex gate → squash-merge flow (per repo CLAUDE.md). Pure JS — OTA-deliverable.

--- a/docs/superpowers/specs/2026-07-30-dealbreakers-exclusion-design.md
+++ b/docs/superpowers/specs/2026-07-30-dealbreakers-exclusion-design.md
@@ -1,0 +1,151 @@
+# Dealbreakers — emphasizing the "I don't want" filtering
+
+**Date:** 2026-07-30
+**Status:** Design approved, pending spec review
+
+## Goal
+
+Make Rouxlette's differentiator — respecting what you *don't* want — a first-class,
+visible feature. The wheel/results already exclude blocked places and (per-search)
+excluded categories; this adds a **persistent "Dealbreakers" list** of cuisines you
+never want, lets you **tweak it per-search**, and **shows it working** via an
+"Avoiding …" bar.
+
+Scoped to **API-matchable dimensions** (cuisine/category + specific-business block) so
+it stays portable across restaurant providers (Yelp today, others later).
+
+## User-facing behavior
+
+- In the **Filters sheet**, a **"Never show me"** section lets the user toggle cuisines
+  they never want (curated common-cuisines chips). These are **persistent** — saved and
+  applied to every search and spin until changed. Toggling applies immediately (it's a
+  standing preference, not gated on "Apply Filters").
+- The existing per-search **cuisine chips** stay above it for this-search include/exclude
+  tweaks (unchanged 3-state behavior).
+- An **"Avoiding: …" bar** appears on Home (near the wheel) and in the Search results
+  header when there is anything to avoid, e.g. `Avoiding: Fast Food, Sushi · 3 blocked`.
+  Tapping it opens the Filters sheet. Only rendered when non-empty.
+- The wheel never lands on, and the results never show, anything matching the effective
+  exclusions.
+
+## Combination & override rule ("baseline + tweak")
+
+Effective excluded cuisines for a search =
+
+```
+(dealbreakerCategoryIds ∪ filters.excludedCategoryIds) − filters.categoryIds
+```
+
+- **Dealbreakers** are the standing NO (baseline).
+- A per-search **exclude** adds to it.
+- A per-search **include** (`filters.categoryIds`, the whitelist chip) **overrides** a
+  dealbreaker for that search only — "actually, sushi tonight."
+- **Blocked places** (`state.blocked`, ID match) are always excluded, independent of
+  categories.
+
+## Data model
+
+`context/state.ts` — `AppState`:
+- Add `dealbreakerCategoryIds: string[]` (canonical cuisine aliases). Default `[]` in
+  `initialAppState`.
+- Unchanged: `filters.excludedCategoryIds`, `filters.categoryIds`, `blocked`.
+
+`context/actions.ts` + `context/reducer.ts`:
+- `ToggleDealbreaker` — payload `{ alias: string }`; adds/removes the alias in
+  `dealbreakerCategoryIds`, then recomputes `results`.
+- `HydrateDealbreakers` — payload `{ aliases: string[] }`; sets the list (from storage),
+  then recomputes `results`.
+- Creators `toggleDealbreaker(alias)`, `hydrateDealbreakers(aliases)`.
+
+## Filtering (single source of truth)
+
+Extend the reducer helper added in #61:
+
+```
+computeVisibleResults(rawResults, filters, blocked, dealbreakers)
+  → applyFilters(rawResults, { ...filters, excludedCategoryIds: effectiveExcluded })
+        .filter(b => !blockedIds.has(b.id))
+
+effectiveExcluded =
+  [...new Set([...dealbreakers, ...filters.excludedCategoryIds])]
+    .filter(alias => !filters.categoryIds.includes(alias))
+```
+
+`applyFilters` (utils/filterBusinesses) is unchanged — it already drops businesses whose
+`categories[].alias` intersects `excludedCategoryIds`; we just feed it the merged set.
+
+Update every call site of `computeVisibleResults` to pass `state.dealbreakerCategoryIds`:
+`SetResults`, `SetFilters`, `ResetFilters`, `ToggleCategoryFilter`, `AddBlocked`,
+`RemoveBlocked`, `HydrateBlocked`, and the new `ToggleDealbreaker`/`HydrateDealbreakers`.
+
+Because filtering stays in `computeVisibleResults`, both the Search results list and
+`state.results` (which the Home wheel spins over) honor dealbreakers automatically — no
+change to `useResults` or the Yelp request. This keeps it **provider-agnostic**: the
+exclusion reads only `business.categories[].alias`, no Yelp-specific field.
+
+## Persistence
+
+New `hooks/useDealbreakers.ts`, mirroring `hooks/useBlocked.ts`:
+- Storage key `'dealbreakers'`; hydrate once on mount → `dispatch(hydrateDealbreakers(...))`;
+  persist `state.dealbreakerCategoryIds` on change (debounced/change-detected like blocked).
+- Called from the same screens that already mount `useBlocked` (Home, Search) so it
+  hydrates regardless of entry route.
+
+## UI
+
+### Curated cuisine list
+- Add `COMMON_CUISINES: { alias: string; label: string }[]` to `constants/foodCategories`
+  — a fixed, predictable set (e.g. Fast Food, Sushi,
+  Buffet, Pizza, Mexican, Chinese, Indian, Thai, Vegan, Steakhouse, …). Fixed list, not
+  derived from current results, since dealbreakers are a standing preference.
+
+### FiltersSheet — "Never show me" section
+- New section below the existing cuisine section: title "Never show me" + subtitle
+  "Always hidden from results".
+- Render `COMMON_CUISINES` as toggle chips; a chip is active when its alias is in
+  `state.dealbreakerCategoryIds`. Active styling uses the 🚫/error-tinted treatment,
+  distinct from the include chips.
+- Tapping a chip dispatches `toggleDealbreaker(alias)` **immediately** (persistent), not
+  through the sheet's local "Apply" flow. A one-line hint clarifies it's always-on.
+
+### AvoidingBar component
+- `components/AvoidingBar.tsx` — a compact row summarizing what's being excluded:
+  dealbreaker labels + per-search exclude labels + `· N blocked`. Tapping opens the
+  Filters sheet (via the existing `setShowFilter(true)`).
+- Rendered on Home (near the wheel) and in the Search results header. On Search it
+  **replaces** the existing "N blocked hidden" summary (#61) — the blocked count folds
+  into this bar. Only shown when non-empty.
+- Label lookup: alias → display name via `COMMON_CUISINES` / existing category labels.
+
+## Edge cases
+
+- **Everything excluded:** if dealbreakers/excludes remove all matches, reuse the existing
+  "all blocked / no matches" empty states; extend copy to mention dealbreakers where
+  relevant.
+- **Dealbreaker + per-search include of the same cuisine:** shown this search (override
+  rule), dealbreaker preserved for next time.
+- **Spin safety:** the Home wheel picks from `state.results` (already dealbreaker/blocked
+  filtered), so it can never land on an excluded cuisine.
+- **Hydration race:** dealbreakers may hydrate after results are set; `HydrateDealbreakers`
+  recomputes `results` (same pattern as `HydrateBlocked` in #61).
+- **Blocked vs dealbreaker counts** in the Avoiding bar are distinct (places vs cuisines).
+
+## Testing
+
+- **reducer:** dealbreaker excludes a matching business from `results` but keeps
+  `rawResults`; per-search *include* of a dealbreaker cuisine overrides it (shown);
+  union with blocked; `HydrateDealbreakers` re-filters results set before hydration.
+- **persistence:** `useDealbreakers` hydrates from and persists to storage.
+- **FiltersSheet:** toggling a "Never show me" chip dispatches `toggleDealbreaker` and
+  reflects active state from `dealbreakerCategoryIds`.
+- **AvoidingBar:** renders the correct summary (cuisines + blocked count); hidden when
+  nothing to avoid; tap opens filters.
+
+## Out of scope (explicit)
+
+- The full **multi-provider adapter layer** (normalizing non-Yelp providers into a shared
+  category taxonomy). This design only ensures the exclusion logic doesn't couple to Yelp;
+  building the abstraction is a separate future effort.
+- **Non-category exclusions** (ingredient/dietary-level, e.g. "no cilantro") — not
+  reliably API-matchable.
+- **Provider query-side exclusion** — we filter client-side, which is portable.

--- a/hooks/useDealbreakers.ts
+++ b/hooks/useDealbreakers.ts
@@ -1,0 +1,72 @@
+import { useContext, useEffect, useRef } from 'react';
+import { RootContext } from '../context/RootContext';
+import { hydrateDealbreakers } from '../context/reducer';
+import { DEBOUNCE_PERSISTENCE_MS } from '../types/favorites';
+import usePersistentStorage from './usePersistentStorage';
+import { logSafe } from '../utils/log';
+
+const STORAGE_KEY_DEALBREAKERS = 'dealbreakers';
+
+// Track hydration globally to prevent multiple hydrations across hook instances
+let dealbreakersHydrated = false;
+
+export function useDealbreakers() {
+  const { state, dispatch } = useContext(RootContext);
+  const storage = usePersistentStorage({
+    keyPrefix: '@roux',
+    debug: __DEV__,
+    debounceMs: DEBOUNCE_PERSISTENCE_MS,
+  });
+  const hasHydratedRef = useRef(false);
+  const lastPersistedRef = useRef<string>('');
+
+  // Hydrate dealbreakers from storage ONCE on first mount
+  useEffect(() => {
+    if (dealbreakersHydrated || hasHydratedRef.current) {
+      return;
+    }
+    hasHydratedRef.current = true;
+    dealbreakersHydrated = true;
+
+    const loadDealbreakers = async () => {
+      try {
+        const storedDealbreakers = await storage.getItem<string[]>(STORAGE_KEY_DEALBREAKERS);
+        if (storedDealbreakers && Array.isArray(storedDealbreakers)) {
+          logSafe('[useDealbreakers] Hydrating dealbreakers', { count: storedDealbreakers.length });
+          dispatch(hydrateDealbreakers(storedDealbreakers));
+          lastPersistedRef.current = JSON.stringify(storedDealbreakers);
+        }
+      } catch (error) {
+        logSafe('[useDealbreakers] Error loading dealbreakers', { error: (error as Error)?.message });
+      }
+    };
+
+    loadDealbreakers();
+  }, [dispatch, storage]);
+
+  // Persist dealbreakers when state changes
+  useEffect(() => {
+    // Don't persist until we've hydrated
+    if (!dealbreakersHydrated) return;
+
+    const currentJson = JSON.stringify(state.dealbreakerCategoryIds);
+    // Skip if nothing changed
+    if (currentJson === lastPersistedRef.current) return;
+
+    const persistDealbreakers = async () => {
+      try {
+        await storage.setItem(STORAGE_KEY_DEALBREAKERS, state.dealbreakerCategoryIds);
+        lastPersistedRef.current = currentJson;
+        logSafe('[useDealbreakers] Persisted dealbreakers', { count: state.dealbreakerCategoryIds.length });
+      } catch (error) {
+        logSafe('[useDealbreakers] Error persisting dealbreakers', { error: (error as Error)?.message });
+      }
+    };
+
+    persistDealbreakers();
+  }, [state.dealbreakerCategoryIds, storage]);
+
+  return {
+    dealbreakers: state.dealbreakerCategoryIds,
+  };
+}

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -23,7 +23,9 @@ import { useRadiusReconcile } from '../hooks/useRadiusReconcile';
 import useLocation from '../hooks/useLocation';
 import { useHistory } from '../hooks/useHistory';
 import { useBlocked } from '../hooks/useBlocked';
+import { useDealbreakers } from '../hooks/useDealbreakers';
 import useCategories from '../hooks/useCategories';
+import { AvoidingBar } from '../components/AvoidingBar';
 import FiltersSheet from '../components/filter/FiltersSheet';
 import { countActiveFilters } from '../utils/filterBusinesses';
 import { RootTabScreenProps } from '../types';
@@ -43,6 +45,8 @@ export const HomeScreen: React.FC = () => {
   const [, city, canonicalLocation, coords, , searchLocation, resolveSearchArea, isLocationLoading, , stopLocationWatcher] = useLocation();
   const { addHistoryEntry } = useHistory();
   const { blocked } = useBlocked();
+  // Hydrate/persist dealbreakers regardless of entry route (mirrors useBlocked).
+  useDealbreakers();
   const { loadCategories } = useCategories();
 
   const isLoading = resultsLoading || isSearching;
@@ -378,6 +382,17 @@ export const HomeScreen: React.FC = () => {
           </Text>
         </View>
 
+        {/* Avoiding bar — summarizes dealbreakers + per-search excludes and opens
+            the Filters sheet. Home has no blocked-hidden count of its own. */}
+        <View style={styles.avoidingBarWrap}>
+          <AvoidingBar
+            dealbreakers={state.dealbreakerCategoryIds}
+            perSearchExcludes={state.filters.excludedCategoryIds}
+            blockedCount={0}
+            onPress={handleFiltersPress}
+          />
+        </View>
+
         {/* Active Filters */}
         {activeFilters.length > 0 && (
           <ActiveFilterBar filters={activeFilters} />
@@ -610,6 +625,10 @@ const styles = StyleSheet.create({
     ...typography.callout,
     color: supperClub.textMuted,
     marginTop: spacing.md,
+  },
+  avoidingBarWrap: {
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.md,
   },
   searchContainer: {
     paddingHorizontal: spacing.md,

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -394,6 +394,7 @@ export const HomeScreen: React.FC = () => {
           <AvoidingBar
             dealbreakers={state.dealbreakerCategoryIds}
             perSearchExcludes={state.filters.excludedCategoryIds}
+            includes={state.filters.categoryIds}
             blockedCount={0}
             onPress={handleFiltersPress}
           />

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -17,7 +17,7 @@ import { LinearGradient } from 'expo-linear-gradient';
 import { spacing, radius, typography } from '../theme';
 import { supperClub, supperClubPalette, supperClubGlow } from '../theme/supperClub';
 import { RootContext } from '../context/RootContext';
-import { setResults, setLastSearch, setShowFilter, addSpinHistory, setSelectedBusiness, showBusinessModal, setFilters, setCategories, setLocation, setCoords } from '../context/reducer';
+import { setResults, setLastSearch, setShowFilter, addSpinHistory, setSelectedBusiness, showBusinessModal, setFilters, setCategories, setLocation, setCoords, computeVisibleResults } from '../context/reducer';
 import useResults, { BusinessProps } from '../hooks/useResults';
 import { useRadiusReconcile } from '../hooks/useRadiusReconcile';
 import useLocation from '../hooks/useLocation';
@@ -168,11 +168,17 @@ export const HomeScreen: React.FC = () => {
         businesses = await searchApi(term, state.location || 'Current Location', coords, radiusMeters);
       }
 
-      // Dispatch the raw set; the reducer excludes blocked from the visible
-      // results. Keep a blocked-excluded set locally so the wheel never lands on
-      // a blocked restaurant.
-      const blockedIds = new Set(blocked.map(b => b.id));
-      const spinnable = businesses.filter(b => !blockedIds.has(b.id));
+      // Dispatch the RAW set; the reducer filters it for the visible results.
+      // The local spin pool must use the SAME filtering authority as the visible
+      // results (dealbreakers + per-search excludes/price/rating + blocked) so
+      // the wheel's first spin after a search can never land on an excluded
+      // restaurant (e.g. a "Never show me" cuisine).
+      const spinnable = computeVisibleResults(
+        businesses,
+        state.filters,
+        blocked,
+        state.dealbreakerCategoryIds,
+      );
 
       dispatch(setResults(businesses));
       // Record the committed search identity for cross-screen radius

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -84,6 +84,22 @@ export const SearchScreen: React.FC = () => {
         ? applyFilters(rawResults, state.filters).filter(b => isBlocked(b.id)).length
         : 0;
 
+    // "All avoided" empty state: the search returned raw matches, but the user's
+    // exclusions (dealbreakers or per-search excludes) hid every visible result.
+    // Distinct from the blocked-only empty state (handled separately) and from
+    // the truly-no-results case (rawResults empty → keep the generic prompt).
+    const isAvoidingSomething =
+        state.dealbreakerCategoryIds.length > 0 || state.filters.excludedCategoryIds.length > 0;
+    const showAllAvoidedEmpty =
+        restaurants.length === 0 &&
+        state.results.length === 0 &&
+        blockedHiddenCount === 0 &&
+        rawResults.length > 0 &&
+        isAvoidingSomething;
+    // How many raw matches the avoidance settings hid (raw minus anything still
+    // visible). Clamped so the copy always reads sensibly in this branch.
+    const avoidedHiddenCount = Math.max(rawResults.length - state.results.length, 1);
+
     // The results hero is the wheel's ACTUAL pick (most recent spin), not just
     // the first result — otherwise the "The wheel picked" badge lands on the
     // wrong restaurant (#48). Gate it on the pick being present in the CURRENT
@@ -472,6 +488,7 @@ export const SearchScreen: React.FC = () => {
                                     <AvoidingBar
                                         dealbreakers={state.dealbreakerCategoryIds}
                                         perSearchExcludes={state.filters.excludedCategoryIds}
+                                        includes={state.filters.categoryIds}
                                         blockedCount={blockedHiddenCount}
                                         onPress={handleFiltersPress}
                                     />
@@ -513,8 +530,29 @@ export const SearchScreen: React.FC = () => {
                 </View>
             )}
 
+            {/* All matches hidden by the user's "Never show me" / exclusion settings.
+                The Avoiding bar is tappable so they can open Filters and adjust. */}
+            {!isLoading && showAllAvoidedEmpty && (
+                <View style={styles.emptyContainer} testID="all-avoided-empty">
+                    <Ionicons name="eye-off-outline" size={64} color={supperClub.textMuted}/>
+                    <Text style={styles.emptyTitle}>Everything was filtered out</Text>
+                    <Text style={styles.emptySubtitle}>
+                        Your "Never show me" settings hid {avoidedHiddenCount} {avoidedHiddenCount === 1 ? 'match' : 'matches'}. Tap below to adjust.
+                    </Text>
+                    <View style={styles.avoidedBarWrap}>
+                        <AvoidingBar
+                            dealbreakers={state.dealbreakerCategoryIds}
+                            perSearchExcludes={state.filters.excludedCategoryIds}
+                            includes={state.filters.categoryIds}
+                            blockedCount={0}
+                            onPress={handleFiltersPress}
+                        />
+                    </View>
+                </View>
+            )}
+
             {/* Empty State */}
-            {!isLoading && restaurants.length === 0 && state.results.length === 0 && blockedHiddenCount === 0 && (
+            {!isLoading && restaurants.length === 0 && state.results.length === 0 && blockedHiddenCount === 0 && !showAllAvoidedEmpty && (
                 <View style={styles.emptyContainer}>
                     <Ionicons name="search-outline" size={64} color={supperClub.textMuted}/>
                     <Text style={styles.emptyTitle}>Search for restaurants</Text>
@@ -751,5 +789,9 @@ const styles = StyleSheet.create({
         color: supperClub.textMuted,
         marginTop: spacing.sm,
         textAlign: 'center',
+    },
+    avoidedBarWrap: {
+        marginTop: spacing.lg,
+        alignSelf: 'stretch',
     },
 });

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -26,6 +26,8 @@ import {useRadiusReconcile} from '../hooks/useRadiusReconcile';
 import useLocation from '../hooks/useLocation';
 import {useBlockFavorite} from '../hooks/useBlockFavorite';
 import {useBlocked} from '../hooks/useBlocked';
+import {useDealbreakers} from '../hooks/useDealbreakers';
+import {AvoidingBar} from '../components/AvoidingBar';
 import FiltersSheet from '../components/filter/FiltersSheet';
 import {applyFilters, countActiveFilters} from '../utils/filterBusinesses';
 import {RootTabScreenProps} from '../types';
@@ -46,6 +48,9 @@ export const SearchScreen: React.FC = () => {
     // even when Search is the entry route (e.g. the /search deep link) and Home
     // never mounts. Blocked exclusion now happens in the reducer off state.blocked.
     useBlocked();
+    // Hydrate/persist dealbreakers regardless of entry route (mirrors useBlocked)
+    // so the persisted avoid-list survives even when Home never mounts.
+    useDealbreakers();
 
     const isLoading = resultsLoading || isSearching;
     const displayLocation = state.location || city || 'Current Location';
@@ -450,26 +455,27 @@ export const SearchScreen: React.FC = () => {
                                 <Text style={styles.resultsCount}>
                                     {restaurants.length} Result{restaurants.length !== 1 ? 's' : ''}
                                 </Text>
-                                {(favoritesCount > 0 || blockedHiddenCount > 0) && (
+                                {favoritesCount > 0 && (
                                     <View style={styles.resultsMetaRow} testID="results-meta">
-                                        {favoritesCount > 0 && (
-                                            <View style={styles.metaChip}>
-                                                <Ionicons name="heart" size={12} color={supperClub.gold}/>
-                                                <Text style={styles.metaText}>
-                                                    {favoritesCount} favorite{favoritesCount !== 1 ? 's' : ''}
-                                                </Text>
-                                            </View>
-                                        )}
-                                        {blockedHiddenCount > 0 && (
-                                            <View style={styles.metaChip}>
-                                                <Ionicons name="eye-off-outline" size={12} color={supperClub.textMuted}/>
-                                                <Text style={styles.metaTextMuted}>
-                                                    {blockedHiddenCount} blocked hidden
-                                                </Text>
-                                            </View>
-                                        )}
+                                        <View style={styles.metaChip}>
+                                            <Ionicons name="heart" size={12} color={supperClub.gold}/>
+                                            <Text style={styles.metaText}>
+                                                {favoritesCount} favorite{favoritesCount !== 1 ? 's' : ''}
+                                            </Text>
+                                        </View>
                                     </View>
                                 )}
+                                {/* The Avoiding bar folds in the blocked-hidden count
+                                    (was a standalone summary) alongside avoided cuisines,
+                                    and opens the Filters sheet to edit them. */}
+                                <View style={styles.avoidingBarWrap}>
+                                    <AvoidingBar
+                                        dealbreakers={state.dealbreakerCategoryIds}
+                                        perSearchExcludes={state.filters.excludedCategoryIds}
+                                        blockedCount={blockedHiddenCount}
+                                        onPress={handleFiltersPress}
+                                    />
+                                </View>
                             </View>
                             <RestaurantTopPick
                                 restaurant={heroRestaurant}
@@ -712,9 +718,8 @@ const styles = StyleSheet.create({
         fontSize: 12,
         color: supperClub.gold,
     },
-    metaTextMuted: {
-        fontSize: 12,
-        color: supperClub.textMuted,
+    avoidingBarWrap: {
+        marginTop: spacing.sm,
     },
     subhead: {
         fontSize: 11,

--- a/screens/__tests__/HomeScreen.filters-cta.test.tsx
+++ b/screens/__tests__/HomeScreen.filters-cta.test.tsx
@@ -41,6 +41,11 @@ jest.mock('../../hooks/useBlocked', () => ({
   useBlocked: () => ({ blocked: [] }),
 }));
 
+// useDealbreakers touches persistent storage; stub it (mounted for its side effect).
+jest.mock('../../hooks/useDealbreakers', () => ({
+  useDealbreakers: () => ({ dealbreakers: [] }),
+}));
+
 jest.mock('../../hooks/useCategories', () => ({
   __esModule: true,
   default: () => ({ loadCategories: () => [] }),

--- a/screens/__tests__/HomeScreen.radius-spin.test.tsx
+++ b/screens/__tests__/HomeScreen.radius-spin.test.tsx
@@ -27,6 +27,8 @@ jest.mock('../../hooks/useLocation', () => ({
 const mockAddHistoryEntry = jest.fn();
 jest.mock('../../hooks/useHistory', () => ({ useHistory: () => ({ addHistoryEntry: mockAddHistoryEntry }) }));
 jest.mock('../../hooks/useBlocked', () => ({ useBlocked: () => ({ blocked: [] }) }));
+// useDealbreakers touches persistent storage; stub it (mounted for its side effect).
+jest.mock('../../hooks/useDealbreakers', () => ({ useDealbreakers: () => ({ dealbreakers: [] }) }));
 jest.mock('../../hooks/useCategories', () => ({ __esModule: true, default: () => ({ loadCategories: () => [] }) }));
 
 jest.mock('../../components/RouletteWheel', () => {

--- a/screens/__tests__/HomeScreen.radius-spin.test.tsx
+++ b/screens/__tests__/HomeScreen.radius-spin.test.tsx
@@ -3,7 +3,7 @@ import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { HomeScreen } from '../HomeScreen';
 import { RootContext } from '../../context/RootContext';
 import { mockInitialState } from '../../__tests__/mocks/mockState';
-import { setLastSearch } from '../../context/reducer';
+import { setLastSearch, setSelectedBusiness } from '../../context/reducer';
 
 jest.mock('@react-navigation/native', () => ({
   useNavigation: () => ({ navigate: jest.fn(), setOptions: jest.fn(), goBack: jest.fn() }),
@@ -59,12 +59,17 @@ jest.mock('@expo/vector-icons', () => {
   const Icon = ({ name }: any) => <Text testID={`icon-${name}`}>{name}</Text>;
   return { Ionicons: Icon, MaterialIcons: Icon, FontAwesome: Icon };
 });
-jest.mock('../../utils/filterBusinesses', () => ({
-  countActiveFilters: jest.fn(() => 0),
-  applyFilters: (results: any[]) => results,
-  DISTANCE_OPTIONS: [{ label: '1 mi', meters: 1600 }],
-  getDistanceLabel: jest.fn(() => '1 mi'),
-}));
+// Use the REAL applyFilters so computeVisibleResults (which the Home first-spin
+// pool now routes through) actually honors category exclusions/dealbreakers.
+jest.mock('../../utils/filterBusinesses', () => {
+  const actual = jest.requireActual('../../utils/filterBusinesses');
+  return {
+    ...actual,
+    countActiveFilters: jest.fn(() => 0),
+    DISTANCE_OPTIONS: [{ label: '1 mi', meters: 1600 }],
+    getDistanceLabel: jest.fn(() => '1 mi'),
+  };
+});
 
 const mockDispatch = jest.fn();
 // Committed search identity lives in shared state (#58). Results present so
@@ -163,6 +168,46 @@ describe('HomeScreen radius refetch on spin (#55/#58)', () => {
       </RootContext.Provider>
     );
     expect(getAllByText('Spinning...').length).toBeGreaterThan(0);
+  });
+
+  it('never auto-spins onto a dealbreakered cuisine after a Home search', async () => {
+    // Regression: the Home first-spin pool was blocked-only, so the wheel could
+    // land on a "Never show me" cuisine. It must now route through the same
+    // filtering as the visible results (dealbreakers + filters + blocked).
+    const sushi = { id: 'sushi-1', name: 'Sushi Spot', categories: [{ alias: 'sushi', title: 'Sushi' }] };
+    const pizza = { id: 'pizza-1', name: 'Pizza Place', categories: [{ alias: 'pizza', title: 'Pizza' }] };
+    // The useLocation mock's resolveSearchArea returns undefined → HomeScreen
+    // falls back to the plain searchApi path.
+    mockSearchApi.mockResolvedValueOnce([sushi, pizza] as any);
+
+    // Force the random pick to index 0. Pre-fix the pool is [sushi, pizza] so
+    // this selects sushi (bug); post-fix the pool is [pizza] so index 0 is pizza.
+    const randomSpy = jest.spyOn(Math, 'random').mockReturnValue(0);
+
+    const state = { ...mockInitialState, dealbreakerCategoryIds: ['sushi'] };
+    const { getByPlaceholderText, getByTestId } = render(
+      <RootContext.Provider value={{ state, dispatch: mockDispatch }}>
+        <HomeScreen />
+      </RootContext.Provider>
+    );
+
+    const input = getByPlaceholderText('What are you craving?');
+    fireEvent.changeText(input, 'food');
+    fireEvent(input, 'submitEditing');
+
+    // Wait for the auto-spin selection to settle, then finish the wheel so the
+    // selected business is dispatched to the modal.
+    await waitFor(() => expect(mockSearchApi).toHaveBeenCalled());
+    fireEvent.press(getByTestId('wheel-complete'));
+
+    // Only the pizza place survives dealbreaker filtering → the pick is
+    // deterministic. The wheel must NEVER select the sushi place.
+    await waitFor(() =>
+      expect(mockDispatch).toHaveBeenCalledWith(setSelectedBusiness(pizza as any))
+    );
+    expect(mockDispatch).not.toHaveBeenCalledWith(setSelectedBusiness(sushi as any));
+
+    randomSpy.mockRestore();
   });
 
   it('does not auto-refetch on an idle radius change (no surprise spin)', () => {

--- a/screens/__tests__/SearchScreen.filters-open.test.tsx
+++ b/screens/__tests__/SearchScreen.filters-open.test.tsx
@@ -28,6 +28,12 @@ jest.mock('../../hooks/useBlocked', () => ({
   useBlocked: () => ({ blocked: [] }),
 }));
 
+// useDealbreakers touches persistent storage; stub it (mounted for its side effect).
+jest.mock('../../hooks/useDealbreakers', () => ({
+  __esModule: true,
+  useDealbreakers: () => ({ dealbreakers: [] }),
+}));
+
 jest.mock('../../hooks/useBlockFavorite', () => ({
   __esModule: true,
   useBlockFavorite: () => ({


### PR DESCRIPTION
## Summary

Adds **Dealbreakers** — a persistent "never show me" cuisine list that makes Rouxlette's "I don't want" filtering a first-class, visible feature. Users set standing cuisine exclusions in the Filters sheet; the wheel and results never surface them, an **Avoiding…** bar showcases what's being filtered, and a per-search include can override a dealbreaker for one search without losing the standing preference.

Scoped to API-matchable dimensions (cuisine category + specific-business block) so it stays portable across restaurant providers (Yelp today, others later) — the exclusion reads only `business.categories[].alias`, no Yelp-specific field.

Design: `docs/superpowers/specs/2026-07-30-dealbreakers-exclusion-design.md`
Plan: `docs/superpowers/plans/2026-07-30-dealbreakers.md`

## What's included

- **Reducer as the single filtering authority** — `computeVisibleResults(rawResults, filters, blocked, dealbreakers)` computes `effectiveExcluded = (dealbreakers ∪ per-search excludes) − per-search includes`, then removes blocked-by-id. Every results-changing action recomputes through it, so both the Search list and `state.results` (which the Home wheel spins over) honor dealbreakers automatically. New `AppState.dealbreakerCategoryIds`, actions `ToggleDealbreaker` / `HydrateDealbreakers`.
- **Persistence** — `hooks/useDealbreakers.ts` mirrors `useBlocked` (storage key `dealbreakers`, hydrate-once guard, persist-on-change). Mounted on Home + Search so it hydrates regardless of entry route.
- **`COMMON_CUISINES`** — curated chip list (Yelp category aliases) in `constants/foodCategories.ts`.
- **FiltersSheet "Never show me" section** — toggle chips reflecting `dealbreakerCategoryIds`; tapping dispatches `toggleDealbreaker` immediately (a standing preference, not gated behind Apply). Error-tinted active styling, distinct from the per-search include chips.
- **`components/AvoidingBar.tsx`** — compact summary ("Avoiding: Sushi, Pizza · 3 blocked") shown on Home (near the wheel) and in the Search results header; tapping opens the Filters sheet. On Search it replaces the older standalone "N blocked hidden" summary (the blocked count folds in). Hidden when there's nothing to avoid.

## Override rule

`(dealbreakerCategoryIds ∪ filters.excludedCategoryIds) − filters.categoryIds`, then blocked-by-id removed on top. A per-search include of a dealbreakered cuisine surfaces it for that search only; the standing list is untouched.

## Testing

TDD throughout. Full suite: **446 passing** (47 suites). TypeScript error count **158** (one below the prior 159 baseline). New coverage: reducer exclusion + override + hydrate re-filter; `useDealbreakers` hydration; `AvoidingBar` dedupe / alias-fallback / blocked-only render; FiltersSheet section (with a mutation-verified active-state assertion); Search AvoidingBar render; and a regression test that the **Home first-spin after a search never lands on a dealbreakered cuisine** (see below).

## Notable fix

A holistic review caught an integration bug per-task review couldn't see: HomeScreen's first auto-spin after a search picked from a blocked-only local pool, bypassing dealbreakers/filters — so the wheel could land on a "Never show me" cuisine on the first spin. Fixed by routing the spin pool through the same exported `computeVisibleResults` used for the visible results, with a deterministic regression test (`Math.random()` stubbed to force the pre-fix failure, confirmed fail→pass).

## Note for reviewers

`COMMON_CUISINES` uses `hotdogs`→"Fast Food" and `indpak`→"Indian", the correct Yelp Fusion aliases for matching `business.categories[].alias`. The pre-existing `FOOD_CATEGORIES` list uses `fastfood`/`indian` for some of these, so the two lists diverge on alias; reconciling the older list is left as separate cleanup.

## Out of scope

Full multi-provider adapter layer; ingredient/dietary-level exclusions (not reliably API-matchable); provider query-side exclusion (we filter client-side for portability).
