### PR TITLE
feat(providers): restaurant provider adapter layer (Yelp + OpenStreetMap fallback)

### DIFF
--- a/__tests__/hooks/useBusinessDetails.test.tsx
+++ b/__tests__/hooks/useBusinessDetails.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Integration guard (I1): the Provider Adapter Layer introduced non-Yelp
+ * (`osm:`) business ids. useBusinessDetails enriches basic search data via the
+ * Yelp detail endpoint — but that endpoint carries the Yelp API key and only
+ * knows Yelp entities. For an OSM business, hitting it always 404s while still
+ * misrouting a key-bearing request to Yelp and burning rate limit.
+ *
+ * These tests lock in that Yelp detail enrichment is SKIPPED for non-Yelp ids
+ * (basic data is kept, no network call), while the normal Yelp-id path still
+ * enriches as before.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+// Mock the Yelp API so we can assert whether the detail endpoint is hit.
+jest.mock('../../api/yelp', () => ({
+  __esModule: true,
+  getBusinessDetails: jest.fn(),
+}));
+import { getBusinessDetails } from '../../api/yelp';
+import {
+  useBusinessDetails,
+  clearBusinessDetailsCache,
+} from '../../hooks/useBusinessDetails';
+import { BusinessProps } from '../../hooks/useResults';
+
+const mockGetBusinessDetails = getBusinessDetails as jest.Mock;
+
+const makeBusiness = (id: string): BusinessProps =>
+  ({
+    id,
+    name: 'Test Spot',
+    image_url: '',
+    rating: 4,
+    price: '$$',
+    location: { city: 'Columbus', display_address: ['1 Main St'], address1: '1 Main St' },
+    categories: [{ alias: 'coffee', title: 'Coffee' }],
+    is_closed: false,
+    coordinates: { latitude: 40, longitude: -83 },
+    url: '',
+    phone: '',
+    display_phone: '',
+    alias: 'test-spot',
+    distance: 100,
+    photos: [],
+    review_count: 0,
+    transactions: [],
+    hours: [],
+  } as unknown as BusinessProps);
+
+describe('useBusinessDetails — non-Yelp provider guard (I1)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Cache is module-level and persists across renders; reset between tests.
+    clearBusinessDetailsCache();
+  });
+
+  it('does NOT call the Yelp detail endpoint for an osm: business, and keeps basic data', async () => {
+    const osm = makeBusiness('osm:node/123');
+
+    // autoFetch=true exercises the auto-fetch effect path used by the winner modal.
+    const { result } = renderHook(() => useBusinessDetails(osm, true));
+
+    // Let the auto-fetch effect settle before asserting it did nothing.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockGetBusinessDetails).not.toHaveBeenCalled();
+    // Basic business data is still exposed.
+    expect(result.current.business.id).toBe('osm:node/123');
+    expect(result.current.business.name).toBe('Test Spot');
+    // Deliberate skip: not stuck loading.
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('does NOT call the Yelp detail endpoint when fetchDetails is invoked manually for an osm: business', async () => {
+    const osm = makeBusiness('osm:way/456');
+
+    const { result } = renderHook(() => useBusinessDetails(osm, false));
+
+    await act(async () => {
+      await result.current.fetchDetails();
+    });
+
+    expect(mockGetBusinessDetails).not.toHaveBeenCalled();
+    expect(result.current.business.id).toBe('osm:way/456');
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('DOES call the Yelp detail endpoint for a normal Yelp id (existing behavior preserved)', async () => {
+    mockGetBusinessDetails.mockResolvedValue({ photos: ['p1'], hours: [{ open: [] }] });
+    const yelpBiz = makeBusiness('abc123');
+
+    const { result } = renderHook(() => useBusinessDetails(yelpBiz, true));
+
+    await waitFor(() => expect(mockGetBusinessDetails).toHaveBeenCalledWith('abc123'));
+    await waitFor(() => expect(result.current.hasDetails).toBe(true));
+  });
+});

--- a/__tests__/hooks/useResults.providers.test.tsx
+++ b/__tests__/hooks/useResults.providers.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Task 5 — useResults must route both search paths through the provider
+ * registry (Yelp primary, OSM fallback) and apply the closed/non-food
+ * post-filter uniformly to whatever the used provider returned. Caching is
+ * gated on the used provider's cachePolicy.
+ */
+import { renderHook, act } from '@testing-library/react-native';
+import useResults from '../../hooks/useResults';
+
+// Mock the registry so we assert useResults routes through it and applies the
+// closed/non-food post-filter to the provider's raw results.
+jest.mock('../../providers', () => ({
+  __esModule: true,
+  DEFAULT_PROVIDERS: [
+    { id: 'yelp', cachePolicy: 'cacheable' },
+    { id: 'osm', cachePolicy: 'cacheable' },
+  ],
+  searchRestaurants: jest.fn(),
+}));
+import { searchRestaurants } from '../../providers';
+const mockSearch = searchRestaurants as jest.Mock;
+
+// Cache-miss storage so the search always reaches the provider path.
+const mockStorage = {
+  getItem: jest.fn(async () => null),
+  setItem: jest.fn(async () => {}),
+  getAllItems: jest.fn(() => []),
+};
+jest.mock('../../hooks/usePersistentStorage', () => ({
+  __esModule: true,
+  default: jest.fn(() => mockStorage),
+}));
+
+const coords = { latitude: 40, longitude: -83 } as any;
+
+const food = {
+  id: 'osm:node/1',
+  name: 'Cafe',
+  categories: [{ alias: 'coffee', title: 'coffee' }],
+  is_closed: false,
+};
+const closed = { id: 'y2', name: 'Closed', categories: [], is_closed: true };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockStorage.getItem.mockResolvedValue(null);
+  mockSearch.mockReset();
+});
+
+describe('useResults routes through the provider registry', () => {
+  it('calls the registry and drops closed businesses (searchApi)', async () => {
+    mockSearch.mockResolvedValue({ results: [food, closed], usedProvider: 'osm', errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    let businesses: any;
+    await act(async () => {
+      businesses = await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(mockSearch).toHaveBeenCalled();
+    // Registry received the clamped radius and the coordinates.
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ term: 'coffee', radiusMeters: 1600, coordinates: coords }),
+    );
+    expect(businesses.map((b: any) => b.id)).toEqual(['osm:node/1']); // closed dropped
+  });
+
+  it('drops non-food (blocked-category) businesses (searchApi)', async () => {
+    const blocked = {
+      id: 'y3',
+      name: 'Body Shop',
+      categories: [{ alias: 'autorepair', title: 'Auto Repair' }],
+      is_closed: false,
+    };
+    mockSearch.mockResolvedValue({ results: [food, blocked], usedProvider: 'yelp', errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    let businesses: any;
+    await act(async () => {
+      businesses = await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(businesses.map((b: any) => b.id)).toEqual(['osm:node/1']); // blocked dropped
+  });
+
+  it('clamps radius to the Yelp maximum before calling the registry', async () => {
+    mockSearch.mockResolvedValue({ results: [], usedProvider: 'osm', errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('coffee', 'Columbus', coords, 99999);
+    });
+
+    const call = mockSearch.mock.calls[0];
+    expect(call[1].radiusMeters).toBeLessThanOrEqual(40000);
+  });
+
+  it('routes searchApiWithResolver through the registry and drops closed', async () => {
+    mockSearch.mockResolvedValue({ results: [food, closed], usedProvider: 'osm', errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    let businesses: any;
+    await act(async () => {
+      businesses = await result.current[3](
+        'coffee',
+        { label: 'Columbus, OH', coords, source: 'geocode' } as any,
+        1600,
+      );
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ term: 'coffee', locationLabel: 'Columbus, OH', radiusMeters: 1600 }),
+    );
+    expect(businesses.map((b: any) => b.id)).toEqual(['osm:node/1']);
+  });
+
+  it('caches when the used provider is cacheable', async () => {
+    mockSearch.mockResolvedValue({ results: [food], usedProvider: 'osm', errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(mockStorage.setItem).toHaveBeenCalled();
+  });
+
+  it('rethrows when the registry itself rejects, preserving #58 semantics', async () => {
+    // A registry-level failure (not a single provider failing — the registry
+    // absorbs those) must still propagate so callers can clear committed state.
+    mockSearch.mockRejectedValue(new Error('registry down'));
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await expect(result.current[2]('coffee', 'Columbus', coords, 1600)).rejects.toThrow('registry down');
+    });
+  });
+
+  it('does not cache when the used provider is not in the cacheable set', async () => {
+    // usedProvider is absent from DEFAULT_PROVIDERS, so the cache-policy lookup
+    // resolves to undefined and caching is skipped.
+    mockSearch.mockResolvedValue({ results: [food], usedProvider: 'unknown' as any, errors: {} });
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/useResults.providers.test.tsx
+++ b/__tests__/hooks/useResults.providers.test.tsx
@@ -141,6 +141,9 @@ describe('useResults routes through the provider registry', () => {
     // Nothing was cached, and results were reset to the empty INIT state.
     expect(mockStorage.setItem).not.toHaveBeenCalled();
     expect(result.current[1].businesses).toEqual([]);
+    // #58 UX contract: the synthetic Error has no `.response`, so the catch
+    // maps it to the network-error message shown to the user.
+    expect(result.current[0]).toMatch(/network/i);
   });
 
   it('does not throw on a genuine empty result (a provider ran without throwing) — #58', async () => {
@@ -156,6 +159,28 @@ describe('useResults routes through the provider registry', () => {
     });
 
     expect(out).toEqual([]);
+  });
+
+  it('rethrows on a total outage via the resolver path (searchApiWithResolver) — #58', async () => {
+    // Mirror of the searchApi total-outage case but through index 3. Guards the
+    // two near-identical tails from drifting apart.
+    mockSearch.mockResolvedValue({ results: [], usedProvider: 'osm', errors: { yelp: 'net', osm: 'net' } });
+
+    const resolvedLocation = {
+      label: 'Columbus, OH',
+      coords,
+      source: 'geocoded' as const,
+    };
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await expect(result.current[3]('coffee', resolvedLocation as any, 1600)).rejects.toThrow();
+    });
+
+    // The resolver path caches via cacheResultsByKey -> storage.setItem; on a
+    // total outage nothing is cached and the network message is surfaced (#58).
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
+    expect(result.current[0]).toMatch(/network/i);
   });
 
   it('rethrows when the registry itself rejects, preserving #58 semantics', async () => {

--- a/__tests__/hooks/useResults.providers.test.tsx
+++ b/__tests__/hooks/useResults.providers.test.tsx
@@ -116,8 +116,8 @@ describe('useResults routes through the provider registry', () => {
     expect(businesses.map((b: any) => b.id)).toEqual(['osm:node/1']);
   });
 
-  it('caches when the used provider is cacheable', async () => {
-    mockSearch.mockResolvedValue({ results: [food], usedProvider: 'osm', errors: {} });
+  it('caches when the PRIMARY (yelp) provider is cacheable', async () => {
+    mockSearch.mockResolvedValue({ results: [food], usedProvider: 'yelp', errors: {} });
 
     const { result } = renderHook(() => useResults());
     await act(async () => {
@@ -125,6 +125,20 @@ describe('useResults routes through the provider registry', () => {
     });
 
     expect(mockStorage.setItem).toHaveBeenCalled();
+  });
+
+  it('does NOT cache a FALLBACK (osm) result even though osm is cacheable', async () => {
+    // OSM is the fallback (not DEFAULT_PROVIDERS[0]). Caching its results under
+    // the plain search key would short-circuit the registry on the next
+    // identical search and stop Yelp from being retried after it recovers.
+    mockSearch.mockResolvedValue({ results: [food], usedProvider: 'osm', errors: { yelp: 'net' } });
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
   });
 
   it('rethrows on a total outage (every provider threw, no results) — #58', async () => {

--- a/__tests__/hooks/useResults.providers.test.tsx
+++ b/__tests__/hooks/useResults.providers.test.tsx
@@ -127,6 +127,37 @@ describe('useResults routes through the provider registry', () => {
     expect(mockStorage.setItem).toHaveBeenCalled();
   });
 
+  it('rethrows on a total outage (every provider threw, no results) — #58', async () => {
+    // Every provider errored AND nothing came back → treat as a network failure:
+    // throw so the catch sets the network message and rethrows, clearing the
+    // committed search identity rather than silently showing an empty state.
+    mockSearch.mockResolvedValue({ results: [], usedProvider: 'osm', errors: { yelp: 'net', osm: 'net' } });
+
+    const { result } = renderHook(() => useResults());
+    await act(async () => {
+      await expect(result.current[2]('coffee', 'Columbus', coords, 1600)).rejects.toThrow();
+    });
+
+    // Nothing was cached, and results were reset to the empty INIT state.
+    expect(mockStorage.setItem).not.toHaveBeenCalled();
+    expect(result.current[1].businesses).toEqual([]);
+  });
+
+  it('does not throw on a genuine empty result (a provider ran without throwing) — #58', async () => {
+    // Yelp threw but OSM ran and returned empty → OSM is NOT in errors, so this
+    // is a valid empty search, not a total outage. Resolve to [] (no throw); the
+    // empty-state UI handles it.
+    mockSearch.mockResolvedValue({ results: [], usedProvider: 'osm', errors: { yelp: 'net' } });
+
+    const { result } = renderHook(() => useResults());
+    let out: any;
+    await act(async () => {
+      out = await result.current[2]('coffee', 'Columbus', coords, 1600);
+    });
+
+    expect(out).toEqual([]);
+  });
+
   it('rethrows when the registry itself rejects, preserving #58 semantics', async () => {
     // A registry-level failure (not a single provider failing — the registry
     // absorbs those) must still propagate so callers can clear committed state.

--- a/__tests__/hooks/useResults.radius.test.ts
+++ b/__tests__/hooks/useResults.radius.test.ts
@@ -8,10 +8,20 @@ import useResults from '../../hooks/useResults';
 import useResultsPersistence from '../../hooks/useResultsPersistence';
 import yelp from '../../api/yelp';
 
-// Mock the Yelp axios client so we can assert the request params.
+// Mock the Yelp axios client so we can assert the request params. useResults now
+// routes through the provider registry (Yelp primary), but the Yelp adapter still
+// calls this client, so the param assertions below exercise the real path.
 jest.mock('../../api/yelp', () => ({
   __esModule: true,
   default: { get: jest.fn() },
+}));
+
+// Mock the Overpass client so the OSM fallback never touches the network. When
+// Yelp returns an empty list the registry falls through to OSM; without this the
+// suite would make a real Overpass request and hang.
+jest.mock('../../api/overpass', () => ({
+  __esModule: true,
+  default: { post: jest.fn(async () => ({ data: { elements: [] } })) },
 }));
 
 // Cache-miss storage so searchApi always reaches the network path.
@@ -91,12 +101,25 @@ describe('useResults radius wiring (#55)', () => {
 });
 
 describe('useResults failure propagation (#58)', () => {
-  it('rejects when the Yelp request fails, so callers can clear committed state', async () => {
+  // With the provider registry in place a single-provider failure is no longer a
+  // hard error: the registry catches it and falls back to OSM. The #58 rethrow
+  // now fires only when the search operation as a whole rejects (e.g. an
+  // unexpected error inside the hook), which we cover via a registry-level throw
+  // in useResults.providers.test.tsx. Here we assert the resilient behavior: a
+  // Yelp outage degrades to the OSM fallback rather than rejecting.
+  it('falls back to OSM when the Yelp request fails (no reject)', async () => {
     mockedGet.mockRejectedValueOnce(new Error('network down'));
+    const overpass = require('../../api/overpass').default;
+    overpass.post.mockResolvedValueOnce({ data: { elements: [] } });
+
     const { result } = renderHook(() => useResults());
+    let out: any;
     await act(async () => {
-      await expect(result.current[2]('pizza', 'Columbus', coords, 1600)).rejects.toThrow('network down');
+      out = await result.current[2]('pizza', 'Columbus', coords, 1600);
     });
+    // Yelp threw, OSM returned nothing → a valid (empty) result set, not a throw.
+    expect(out).toEqual([]);
+    expect(overpass.post).toHaveBeenCalled();
   });
 
   it('still resolves an empty array for a genuine no-results response', async () => {

--- a/__tests__/utils/filterBusinesses.test.ts
+++ b/__tests__/utils/filterBusinesses.test.ts
@@ -188,36 +188,42 @@ describe('filterBusinesses', () => {
     });
 
     describe('price level filtering', () => {
-      it('should filter by single price level', () => {
+      it('should filter by single price level (unknown price also passes)', () => {
         const filters: Filters = {
           ...initialFilters,
           priceLevels: [2] // $$
         };
         const result = applyFilters(mockBusinesses, filters);
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe('Pizza Palace');
+        // Pizza Palace ($$) matches; No Price Restaurant (unknown price) passes
+        // because a price filter only drops businesses with a KNOWN, unselected
+        // price (#providers).
+        expect(result).toHaveLength(2);
+        expect(result.map(b => b.name)).toEqual(['Pizza Palace', 'No Price Restaurant']);
       });
 
-      it('should filter by multiple price levels', () => {
+      it('should filter by multiple price levels (unknown price also passes)', () => {
         const filters: Filters = {
           ...initialFilters,
           priceLevels: [1, 3] // $ and $$$
         };
         const result = applyFilters(mockBusinesses, filters);
-        expect(result).toHaveLength(2);
-        expect(result.map(b => b.name)).toEqual(['Sushi Spot', 'Budget Burgers']);
+        // Sushi Spot ($$$) and Budget Burgers ($) match; No Price Restaurant
+        // (unknown price) passes too (#providers).
+        expect(result).toHaveLength(3);
+        expect(result.map(b => b.name)).toEqual(['Sushi Spot', 'Budget Burgers', 'No Price Restaurant']);
       });
 
-      it('should exclude businesses without price information', () => {
+      it('should keep businesses without price information (missing != fail)', () => {
+        // Multi-provider intent (#providers): a business with an unknown price
+        // (e.g. OSM, which has no price level) must not be dropped by a price
+        // filter. Only businesses whose KNOWN price is unselected are excluded.
         const filters: Filters = {
           ...initialFilters,
           priceLevels: [1]
         };
         const result = applyFilters(mockBusinesses, filters);
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe('Budget Burgers');
-        // 'No Price Restaurant' should be excluded
-        expect(result.find(b => b.name === 'No Price Restaurant')).toBeUndefined();
+        expect(result).toHaveLength(2);
+        expect(result.map(b => b.name)).toEqual(['Budget Burgers', 'No Price Restaurant']);
       });
     });
 
@@ -297,7 +303,10 @@ describe('filterBusinesses', () => {
         expect(result).toHaveLength(5);
       });
 
-      it('should exclude businesses without rating data when minRating > 0', () => {
+      it('should keep businesses without rating data when minRating > 0 (missing != fail)', () => {
+        // Multi-provider intent (#providers): an unknown rating (undefined / 0,
+        // e.g. OSM which has no crowd rating) must not be dropped by a minRating
+        // filter. Only a KNOWN rating below the threshold is excluded.
         const businessesWithoutRating = [
           { ...mockBusinesses[0], rating: undefined },
           mockBusinesses[1]
@@ -307,8 +316,8 @@ describe('filterBusinesses', () => {
           minRating: 3.0
         };
         const result = applyFilters(businessesWithoutRating, filters);
-        expect(result).toHaveLength(1);
-        expect(result[0].name).toBe('Sushi Spot');
+        expect(result).toHaveLength(2);
+        expect(result.map(b => b.name)).toEqual(['Pizza Palace', 'Sushi Spot']);
       });
     });
 
@@ -338,6 +347,40 @@ describe('filterBusinesses', () => {
         };
         const result = applyFilters(mockBusinesses, filters);
         expect(result).toHaveLength(0);
+      });
+    });
+
+    describe('missing data is not excluded (#providers)', () => {
+      const base = {
+        categoryIds: [],
+        excludedCategoryIds: [],
+        priceLevels: [],
+        openNow: false,
+        radiusMeters: 40000,
+        minRating: 0,
+      } as Filters;
+      const biz = (over: Partial<BusinessProps>) => ({
+        id: 'x',
+        name: 'x',
+        categories: [],
+        distance: 100,
+        price: '',
+        rating: 0,
+        is_closed: false,
+        ...over,
+      } as BusinessProps);
+
+      it('keeps a business with unknown price when a price filter is active', () => {
+        expect(applyFilters([biz({ price: '' })], { ...base, priceLevels: [2] })).toHaveLength(1);
+      });
+      it('still excludes a business whose known price is not selected', () => {
+        expect(applyFilters([biz({ price: '$$$$' })], { ...base, priceLevels: [1] })).toHaveLength(0);
+      });
+      it('keeps a business with unknown rating when a minRating filter is active', () => {
+        expect(applyFilters([biz({ rating: 0 })], { ...base, minRating: 4 })).toHaveLength(1);
+      });
+      it('still excludes a business whose known rating is below minRating', () => {
+        expect(applyFilters([biz({ rating: 3 })], { ...base, minRating: 4 })).toHaveLength(0);
       });
     });
   });

--- a/api/overpass.ts
+++ b/api/overpass.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+// Public Overpass endpoint. Configurable so it can be swapped or self-hosted.
+// Overpass requires an identifying User-Agent/Referer.
+const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+
+const overpass = axios.create({
+  baseURL: OVERPASS_URL,
+  headers: { 'Content-Type': 'text/plain', 'User-Agent': 'Rouxlette/1.0 (https://github.com/keif/rouxlette)' },
+  timeout: 15000,
+});
+
+export default overpass;

--- a/api/overpass.ts
+++ b/api/overpass.ts
@@ -6,6 +6,8 @@ const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
 
 const overpass = axios.create({
   baseURL: OVERPASS_URL,
+  // User-Agent is best-effort identification: the RN native network layer may
+  // drop/override it. It is honored under Node/tests and any non-native path.
   headers: { 'Content-Type': 'text/plain', 'User-Agent': 'Rouxlette/1.0 (https://github.com/keif/rouxlette)' },
   timeout: 15000,
 });

--- a/components/shared/ProviderAttribution.tsx
+++ b/components/shared/ProviderAttribution.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { BusinessProps } from '../../hooks/useResults';
+import { supperClub } from '../../theme/supperClub';
+
+/**
+ * ODbL compliance: whenever any displayed business originates from OpenStreetMap
+ * (its `id` is prefixed `osm:`), we must surface "© OpenStreetMap contributors".
+ * For all-Yelp result sets this renders nothing, preserving the existing look.
+ */
+export const ProviderAttribution: React.FC<{ businesses: BusinessProps[] }> = ({ businesses }) => {
+  const hasOsm = businesses.some(b => typeof b.id === 'string' && b.id.startsWith('osm:'));
+  if (!hasOsm) return null;
+  return <Text style={styles.text}>Data © OpenStreetMap contributors</Text>;
+};
+
+const styles = StyleSheet.create({
+  text: { fontSize: 11, color: supperClub.textMuted, textAlign: 'center', paddingVertical: 8 },
+});
+
+export default ProviderAttribution;

--- a/components/shared/__tests__/ProviderAttribution.test.tsx
+++ b/components/shared/__tests__/ProviderAttribution.test.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ProviderAttribution } from '../ProviderAttribution';
+
+describe('ProviderAttribution', () => {
+  it('shows OSM attribution when an osm business is present', () => {
+    const { getByText } = render(
+      <ProviderAttribution businesses={[{ id: 'osm:node/1' } as any, { id: 'y1' } as any]} />
+    );
+    expect(getByText(/OpenStreetMap/)).toBeTruthy();
+  });
+  it('renders nothing when no osm businesses are present', () => {
+    const { queryByText } = render(
+      <ProviderAttribution businesses={[{ id: 'y1' } as any]} />
+    );
+    expect(queryByText(/OpenStreetMap/)).toBeNull();
+  });
+  it('renders nothing for an empty list', () => {
+    const { queryByText } = render(<ProviderAttribution businesses={[]} />);
+    expect(queryByText(/OpenStreetMap/)).toBeNull();
+  });
+});

--- a/docs/superpowers/plans/2026-07-30-provider-adapter-layer.md
+++ b/docs/superpowers/plans/2026-07-30-provider-adapter-layer.md
@@ -1,0 +1,834 @@
+# Restaurant Provider Adapter Layer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Route restaurant search through a thin provider-adapter layer so Rouxlette can fall back from Yelp to a free OpenStreetMap source, without changing the reducer, Dealbreakers, or UI contracts.
+
+**Architecture:** A `RestaurantProvider` interface (`search()` + `cachePolicy`) with a fallback-only registry (`searchRestaurants`). Yelp and OSM adapters both produce the existing `BusinessProps` shape (reused as the normalized type — no new type, no churn). `useResults` calls the registry instead of Yelp directly. OSM's missing rating/price are represented as `rating: 0` / `price: ''` (which already mean "unknown" in the Yelp-shaped world), and `applyFilters` is corrected so a price/rating filter never excludes a business merely for lacking that field.
+
+**Tech Stack:** React Native + Expo, TypeScript, axios, jest-expo + @testing-library/react-native.
+
+**Spec:** `docs/superpowers/specs/2026-07-30-provider-adapter-layer-design.md`
+
+**Conventions:** yarn. Run tests with `yarn jest <path>`. Every task ends with `yarn jest` (full suite green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (**baseline 158 — must not increase**), then a commit.
+
+**Implementation decisions locked here (spec left these to the plan):**
+- **Bridge, don't unify:** reuse `BusinessProps` (from `hooks/useResults.ts`) as the normalized type. Adapters return `BusinessProps[]`.
+- **Unknown fields:** OSM sets `rating: 0`, `review_count: 0`, `price: ''`, `hours: undefined`. These already read as "unknown" across the existing UI (`rating && …`, `price || '—'`, no-hours → openNow excludes).
+- **Search params carry both coords and an optional location label** so both existing search functions route cleanly; OSM requires coords (returns `[]` without them).
+
+## File structure
+
+- `providers/types.ts` — `ProviderId`, `RestaurantProvider`, `ProviderSearchParams`, `SearchOutcome`.
+- `providers/registry.ts` — `searchRestaurants(providers, params)` fallback logic + `DEFAULT_PROVIDERS`.
+- `providers/yelpProvider.ts` — Yelp adapter (wraps `api/yelp.ts`).
+- `providers/osmProvider.ts` — OSM adapter (Overpass) + cuisine→alias map + haversine.
+- `api/overpass.ts` — axios client for the Overpass endpoint (mockable, mirrors `api/yelp.ts`).
+- `utils/filterBusinesses.ts` — correct price/rating filters for missing data.
+- `hooks/useResults.ts` — route both search functions through the registry; cache-policy gate; expose `usedProvider`.
+- `components/shared/ProviderAttribution.tsx` — "© OpenStreetMap contributors" when OSM results are shown.
+- Tests alongside each.
+
+---
+
+### Task 1: Provider types + fallback registry
+
+**Files:**
+- Create: `providers/types.ts`
+- Create: `providers/registry.ts`
+- Test: `providers/__tests__/registry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `providers/__tests__/registry.test.ts`:
+```ts
+import { searchRestaurants } from '../registry';
+import { RestaurantProvider, ProviderSearchParams } from '../types';
+
+const params: ProviderSearchParams = {
+  term: 'pizza',
+  coordinates: { latitude: 40, longitude: -83 },
+  radiusMeters: 1600,
+};
+const biz = (id: string) => ({ id, name: id, categories: [] } as any);
+
+const provider = (id: any, impl: () => Promise<any[]>): RestaurantProvider =>
+  ({ id, cachePolicy: 'cacheable', search: impl });
+
+describe('searchRestaurants (fallback-only)', () => {
+  it('returns the primary provider results and does not call the fallback', async () => {
+    const osm = jest.fn().mockResolvedValue([biz('o1')]);
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.resolve([biz('y1')])), provider('osm', osm)],
+      params,
+    );
+    expect(out.results.map(b => b.id)).toEqual(['y1']);
+    expect(out.usedProvider).toBe('yelp');
+    expect(osm).not.toHaveBeenCalled();
+  });
+
+  it('falls back when the primary throws', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.reject(new Error('boom'))), provider('osm', () => Promise.resolve([biz('o1')]))],
+      params,
+    );
+    expect(out.results.map(b => b.id)).toEqual(['o1']);
+    expect(out.usedProvider).toBe('osm');
+    expect(out.errors.yelp).toContain('boom');
+  });
+
+  it('falls back when the primary returns empty', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.resolve([])), provider('osm', () => Promise.resolve([biz('o1')]))],
+      params,
+    );
+    expect(out.usedProvider).toBe('osm');
+    expect(out.results.map(b => b.id)).toEqual(['o1']);
+  });
+
+  it('returns empty with errors when all providers fail or are empty', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.reject(new Error('x'))), provider('osm', () => Promise.resolve([]))],
+      params,
+    );
+    expect(out.results).toEqual([]);
+    expect(out.usedProvider).toBe('osm'); // last attempted
+    expect(out.errors.yelp).toContain('x');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest providers/__tests__/registry.test.ts` → FAIL (modules don't exist).
+
+- [ ] **Step 3: Implement types**
+
+Create `providers/types.ts`:
+```ts
+import { BusinessProps, CoordinatesProps } from '../hooks/useResults';
+
+export type ProviderId = 'yelp' | 'osm';
+
+export interface ProviderSearchParams {
+  term: string;
+  coordinates: CoordinatesProps | null; // OSM requires this; Yelp prefers it
+  locationLabel?: string;                // Yelp fallback when no coords
+  radiusMeters: number;
+  signal?: AbortSignal;
+}
+
+export interface RestaurantProvider {
+  id: ProviderId;
+  cachePolicy: 'cacheable' | 'no-store';
+  search(params: ProviderSearchParams): Promise<BusinessProps[]>;
+}
+
+export interface SearchOutcome {
+  results: BusinessProps[];
+  usedProvider: ProviderId | null;
+  errors: Partial<Record<ProviderId, string>>;
+}
+```
+
+- [ ] **Step 4: Implement the registry**
+
+Create `providers/registry.ts`:
+```ts
+import { logSafe } from '../utils/log';
+import { ProviderSearchParams, RestaurantProvider, SearchOutcome } from './types';
+
+/**
+ * Fallback-only search: try providers in order; return the first non-empty
+ * result. A provider that throws is logged and skipped. If every provider is
+ * empty or throws, return an empty result set with the per-provider errors.
+ */
+export async function searchRestaurants(
+  providers: RestaurantProvider[],
+  params: ProviderSearchParams,
+): Promise<SearchOutcome> {
+  const errors: SearchOutcome['errors'] = {};
+  let usedProvider: SearchOutcome['usedProvider'] = null;
+
+  for (const provider of providers) {
+    usedProvider = provider.id;
+    try {
+      const results = await provider.search(params);
+      if (results.length > 0) {
+        return { results, usedProvider, errors };
+      }
+    } catch (err: any) {
+      errors[provider.id] = err?.message ?? String(err);
+      logSafe('[providers] provider search failed', { providerId: provider.id, message: errors[provider.id] });
+    }
+  }
+  return { results: [], usedProvider, errors };
+}
+```
+(`DEFAULT_PROVIDERS` is added in Task 5 once both adapters exist, to avoid an import cycle before they're built.)
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `yarn jest providers/__tests__/registry.test.ts` → PASS.
+
+- [ ] **Step 6: Full suite + typecheck + commit**
+
+Run `yarn jest` (green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (≤158).
+```bash
+git add providers/types.ts providers/registry.ts providers/__tests__/registry.test.ts
+git commit -m "feat(providers): provider interface + fallback-only search registry"
+```
+
+---
+
+### Task 2: Yelp provider adapter
+
+**Files:**
+- Create: `providers/yelpProvider.ts`
+- Test: `providers/__tests__/yelpProvider.test.ts`
+
+Extract the Yelp request from `useResults` into an adapter. It builds the same params (`term`, `limit: 50`, `categories: 'restaurants,food,bars,cafes,bakeries,desserts,coffee'`, plus coords+radius OR location+radius), calls `yelp.get('/businesses/search')`, and returns `response.data.businesses` as `BusinessProps[]` (the Yelp JSON already matches `BusinessProps`). It does NOT filter closed/non-food or cache — those stay in `useResults` and apply to all providers.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `providers/__tests__/yelpProvider.test.ts`:
+```ts
+import { yelpProvider } from '../yelpProvider';
+
+jest.mock('../../api/yelp', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+import yelp from '../../api/yelp';
+const mockGet = (yelp as any).get as jest.Mock;
+
+describe('yelpProvider', () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it('searches by coordinates and returns businesses', async () => {
+    mockGet.mockResolvedValue({ data: { businesses: [{ id: 'y1', name: 'A', categories: [] }] } });
+    const out = await yelpProvider.search({
+      term: 'pizza',
+      coordinates: { latitude: 40, longitude: -83 },
+      radiusMeters: 1600,
+    });
+    expect(out.map(b => b.id)).toEqual(['y1']);
+    const [, opts] = mockGet.mock.calls[0];
+    expect(opts.params.latitude).toBe(40);
+    expect(opts.params.longitude).toBe(-83);
+    expect(opts.params.radius).toBe(1600);
+    expect(opts.params.term).toBe('pizza');
+  });
+
+  it('searches by location label when no coordinates', async () => {
+    mockGet.mockResolvedValue({ data: { businesses: [] } });
+    await yelpProvider.search({ term: 'tacos', coordinates: null, locationLabel: 'Columbus, OH', radiusMeters: 3000 });
+    const [, opts] = mockGet.mock.calls[0];
+    expect(opts.params.location).toBe('Columbus, OH');
+    expect(opts.params.latitude).toBeUndefined();
+  });
+
+  it('returns [] when the response has no businesses array', async () => {
+    mockGet.mockResolvedValue({ data: {} });
+    const out = await yelpProvider.search({ term: 'x', coordinates: { latitude: 1, longitude: 2 }, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+  });
+
+  it('has cachePolicy cacheable and id yelp', () => {
+    expect(yelpProvider.id).toBe('yelp');
+    expect(yelpProvider.cachePolicy).toBe('cacheable');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest providers/__tests__/yelpProvider.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `providers/yelpProvider.ts`:
+```ts
+import yelp from '../api/yelp';
+import { BusinessProps } from '../hooks/useResults';
+import { ProviderSearchParams, RestaurantProvider } from './types';
+
+const YELP_CATEGORIES = 'restaurants,food,bars,cafes,bakeries,desserts,coffee';
+
+export const yelpProvider: RestaurantProvider = {
+  id: 'yelp',
+  cachePolicy: 'cacheable',
+  async search({ term, coordinates, locationLabel, radiusMeters }: ProviderSearchParams): Promise<BusinessProps[]> {
+    const params: any = { term, limit: 50, categories: YELP_CATEGORIES, radius: radiusMeters };
+    if (coordinates?.latitude && coordinates?.longitude) {
+      params.latitude = coordinates.latitude;
+      params.longitude = coordinates.longitude;
+    } else if (locationLabel && locationLabel.trim() !== '') {
+      params.location = locationLabel;
+    } else {
+      return [];
+    }
+    const response = await yelp.get('/businesses/search', { params });
+    const businesses = response?.data?.businesses;
+    return Array.isArray(businesses) ? (businesses as BusinessProps[]) : [];
+  },
+};
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest providers/__tests__/yelpProvider.test.ts` → PASS.
+
+- [ ] **Step 5: Full suite + typecheck + commit**
+
+```bash
+git add providers/yelpProvider.ts providers/__tests__/yelpProvider.test.ts
+git commit -m "feat(providers): Yelp adapter behind the provider interface"
+```
+
+---
+
+### Task 3: OSM (Overpass) provider adapter
+
+**Files:**
+- Create: `api/overpass.ts`
+- Create: `providers/osmCuisineMap.ts`
+- Create: `providers/osmProvider.ts`
+- Test: `providers/__tests__/osmProvider.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `providers/__tests__/osmProvider.test.ts`:
+```ts
+import { osmProvider } from '../osmProvider';
+
+jest.mock('../../api/overpass', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
+import overpass from '../../api/overpass';
+const mockPost = (overpass as any).post as jest.Mock;
+
+const coords = { latitude: 40.0, longitude: -83.0 };
+
+describe('osmProvider', () => {
+  beforeEach(() => mockPost.mockReset());
+
+  it('maps Overpass elements to BusinessProps with unknown rating/price', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'node', id: 1, lat: 40.001, lon: -83.001, tags: { name: 'Sushi Place', cuisine: 'sushi', opening_hours: 'Mo-Su 11:00-22:00', 'addr:city': 'Columbus' } },
+      { type: 'node', id: 2, lat: 40.002, lon: -83.002, tags: { name: 'Curry House', cuisine: 'indian;vegetarian' } },
+    ] } });
+
+    const out = await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+
+    expect(out.map(b => b.id)).toEqual(['osm:node/1', 'osm:node/2']);
+    expect(out[0].name).toBe('Sushi Place');
+    expect(out[0].rating).toBe(0);
+    expect(out[0].review_count).toBe(0);
+    expect(out[0].price).toBe('');
+    expect(out[0].is_closed).toBe(false);
+    expect(out[0].categories.map(c => c.alias)).toContain('sushi');
+    // 'indian' maps to canonical 'indpak'; unknown 'vegetarian' passes through
+    expect(out[1].categories.map(c => c.alias)).toEqual(expect.arrayContaining(['indpak', 'vegetarian']));
+    expect(out[0].distance).toBeGreaterThan(0);
+  });
+
+  it('drops elements without a name', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [ { type: 'node', id: 3, lat: 40, lon: -83, tags: { cuisine: 'pizza' } } ] } });
+    const out = await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+  });
+
+  it('filters by term against name/cuisine when a term is given', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'node', id: 1, lat: 40, lon: -83, tags: { name: 'Pizza Palace', cuisine: 'pizza' } },
+      { type: 'node', id: 2, lat: 40, lon: -83, tags: { name: 'Taco Town', cuisine: 'mexican' } },
+    ] } });
+    const out = await osmProvider.search({ term: 'pizza', coordinates: coords, radiusMeters: 1600 });
+    expect(out.map(b => b.name)).toEqual(['Pizza Palace']);
+  });
+
+  it('returns [] when no coordinates are provided', async () => {
+    const out = await osmProvider.search({ term: 'x', coordinates: null, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('is cacheable with id osm', () => {
+    expect(osmProvider.id).toBe('osm');
+    expect(osmProvider.cachePolicy).toBe('cacheable');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest providers/__tests__/osmProvider.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement the Overpass client**
+
+Create `api/overpass.ts` (mirrors `api/yelp.ts` structure; endpoint configurable):
+```ts
+import axios from 'axios';
+
+// Public Overpass endpoint. Configurable so it can be swapped or self-hosted.
+// Overpass requires an identifying User-Agent/Referer.
+const OVERPASS_URL = 'https://overpass-api.de/api/interpreter';
+
+const overpass = axios.create({
+  baseURL: OVERPASS_URL,
+  headers: { 'Content-Type': 'text/plain', 'User-Agent': 'Rouxlette/1.0 (https://github.com/keif/rouxlette)' },
+  timeout: 15000,
+});
+
+export default overpass;
+```
+
+- [ ] **Step 4: Implement the cuisine map**
+
+Create `providers/osmCuisineMap.ts`:
+```ts
+// Maps common OSM `cuisine=*` values into the canonical (Yelp-style) alias space
+// used by COMMON_CUISINES and the Dealbreakers filter. Unknown values pass
+// through lowercased so they still display (they just won't match a curated chip).
+const OSM_CUISINE_TO_ALIAS: Record<string, string> = {
+  indian: 'indpak',
+  sushi: 'sushi',
+  japanese: 'japanese',
+  pizza: 'pizza',
+  italian: 'italian',
+  mexican: 'mexican',
+  chinese: 'chinese',
+  thai: 'thai',
+  burger: 'burgers',
+  seafood: 'seafood',
+  vegan: 'vegan',
+  american: 'tradamerican',
+  coffee_shop: 'coffee',
+};
+
+export function mapCuisineToAliases(cuisine: string | undefined): string[] {
+  if (!cuisine) return [];
+  return cuisine
+    .split(';')
+    .map(c => c.trim().toLowerCase())
+    .filter(Boolean)
+    .map(c => OSM_CUISINE_TO_ALIAS[c] ?? c);
+}
+```
+
+- [ ] **Step 5: Implement the OSM provider**
+
+Create `providers/osmProvider.ts`:
+```ts
+import overpass from '../api/overpass';
+import { BusinessProps, CoordinatesProps } from '../hooks/useResults';
+import { ProviderSearchParams, RestaurantProvider } from './types';
+import { mapCuisineToAliases } from './osmCuisineMap';
+
+function haversineMeters(a: CoordinatesProps, lat: number, lon: number): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat - a.latitude);
+  const dLon = toRad(lon - a.longitude);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.latitude)) * Math.cos(toRad(lat)) * Math.sin(dLon / 2) ** 2;
+  return Math.round(R * 2 * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s)));
+}
+
+function buildQuery(coords: CoordinatesProps, radiusMeters: number): string {
+  const around = `(around:${radiusMeters},${coords.latitude},${coords.longitude})`;
+  return `[out:json][timeout:25];(node["amenity"="restaurant"]${around};way["amenity"="restaurant"]${around};);out center 50;`;
+}
+
+function elementCoords(el: any): { lat: number; lon: number } | null {
+  if (typeof el.lat === 'number' && typeof el.lon === 'number') return { lat: el.lat, lon: el.lon };
+  if (el.center) return { lat: el.center.lat, lon: el.center.lon };
+  return null;
+}
+
+export const osmProvider: RestaurantProvider = {
+  id: 'osm',
+  cachePolicy: 'cacheable',
+  async search({ term, coordinates, radiusMeters, signal }: ProviderSearchParams): Promise<BusinessProps[]> {
+    if (!coordinates?.latitude || !coordinates?.longitude) return [];
+
+    const response = await overpass.post('', buildQuery(coordinates, radiusMeters), { signal });
+    const elements: any[] = Array.isArray(response?.data?.elements) ? response.data.elements : [];
+    const q = term.trim().toLowerCase();
+
+    const businesses: BusinessProps[] = [];
+    for (const el of elements) {
+      const tags = el.tags || {};
+      const name: string = tags.name;
+      if (!name) continue; // unnamed POIs aren't useful to show
+
+      const pos = elementCoords(el);
+      if (!pos) continue;
+
+      const aliases = mapCuisineToAliases(tags.cuisine);
+
+      if (q) {
+        const haystack = `${name} ${tags.cuisine || ''}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
+      }
+
+      businesses.push({
+        id: `osm:${el.type}/${el.id}`,
+        alias: '',
+        name,
+        coordinates: { latitude: pos.lat, longitude: pos.lon },
+        categories: aliases.map(a => ({ alias: a, title: a })),
+        rating: 0,          // unknown (OSM has no crowd rating)
+        review_count: 0,
+        price: '',          // unknown (OSM has no price level)
+        hours: undefined,   // unknown; openNow filter will exclude (see filter task)
+        is_closed: false,
+        distance: haversineMeters(coordinates, pos.lat, pos.lon),
+        display_phone: tags.phone || '',
+        phone: tags.phone || '',
+        image_url: '',
+        photos: [],
+        transactions: [],
+        url: '',
+        location: {
+          address1: tags['addr:street'] || '',
+          address2: null,
+          address3: '',
+          city: tags['addr:city'] || '',
+          country: tags['addr:country'] || '',
+          display_address: [tags['addr:street'], tags['addr:city']].filter(Boolean) as string[],
+          state: tags['addr:state'] || '',
+          zip_code: tags['addr:postcode'] || '',
+        },
+      });
+    }
+    return businesses;
+  },
+};
+```
+
+- [ ] **Step 6: Run to verify it passes**
+
+Run: `yarn jest providers/__tests__/osmProvider.test.ts` → PASS.
+
+- [ ] **Step 7: Full suite + typecheck + commit**
+
+```bash
+git add api/overpass.ts providers/osmCuisineMap.ts providers/osmProvider.ts providers/__tests__/osmProvider.test.ts
+git commit -m "feat(providers): OpenStreetMap (Overpass) adapter with cuisine-alias mapping"
+```
+
+---
+
+### Task 4: Graceful price/rating filtering for missing data
+
+**Files:**
+- Modify: `utils/filterBusinesses.ts`
+- Test: `utils/__tests__/filterBusinesses.test.ts` (or wherever its tests live — check first; if none, create this path)
+
+Per the approved decision, a price or rating filter must exclude a business only when it HAS a value that fails the filter — never for lacking the field. Today the code excludes missing values (`if (!business.price) return false;` and `if (!business.rating || …) return false;`), which would nuke every OSM result whenever those filters are on.
+
+- [ ] **Step 1: Write the failing test**
+
+First check for an existing test file: `ls utils/__tests__ 2>/dev/null; grep -rl "applyFilters" __tests__ utils 2>/dev/null`. Add these cases to the existing `applyFilters` test file (or create `utils/__tests__/filterBusinesses.test.ts` importing `applyFilters` from `../filterBusinesses` and `initialAppState` filters as a base). Use a base `filters` object matching `Filters` (spread from `initialAppState.filters` if imported, or construct: `{ categoryIds: [], excludedCategoryIds: [], priceLevels: [], openNow: false, radiusMeters: 40000, minRating: 0 }`).
+```ts
+const base = { categoryIds: [], excludedCategoryIds: [], priceLevels: [], openNow: false, radiusMeters: 40000, minRating: 0 } as any;
+const biz = (over: any) => ({ id: 'x', name: 'x', categories: [], distance: 100, price: '', rating: 0, is_closed: false, ...over } as any);
+
+describe('applyFilters — missing data is not excluded (#providers)', () => {
+  it('keeps a business with unknown price when a price filter is active', () => {
+    const out = applyFilters([biz({ price: '' })], { ...base, priceLevels: [2] });
+    expect(out).toHaveLength(1);
+  });
+  it('still excludes a business whose known price is not selected', () => {
+    const out = applyFilters([biz({ price: '$$$$' })], { ...base, priceLevels: [1] });
+    expect(out).toHaveLength(0);
+  });
+  it('keeps a business with unknown rating when a minRating filter is active', () => {
+    const out = applyFilters([biz({ rating: 0 })], { ...base, minRating: 4 });
+    expect(out).toHaveLength(1);
+  });
+  it('still excludes a business whose known rating is below minRating', () => {
+    const out = applyFilters([biz({ rating: 3 })], { ...base, minRating: 4 });
+    expect(out).toHaveLength(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest -t "missing data is not excluded"` → the two "keeps … unknown" cases FAIL (current code excludes them).
+
+- [ ] **Step 3: Fix `applyFilters`**
+
+In `utils/filterBusinesses.ts`, replace the price block:
+```ts
+    // Price filter — only exclude a business that HAS a price not in the
+    // selected levels. Unknown price (e.g. OSM) passes (#providers).
+    if (filters.priceLevels.length > 0 && business.price) {
+      const businessPriceLevel = business.price.length as 1 | 2 | 3 | 4;
+      if (!filters.priceLevels.includes(businessPriceLevel)) {
+        return false;
+      }
+    }
+```
+and replace the minimum-rating block:
+```ts
+    // Minimum rating filter — only exclude a business that HAS a rating below
+    // the threshold. Unknown rating (0 / null, e.g. OSM) passes (#providers).
+    if (filters.minRating > 0 && business.rating && business.rating < filters.minRating) {
+      return false;
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes + check no regressions**
+
+Run: `yarn jest utils` (and any suite that imports `applyFilters`). If an EXISTING test asserted the old "exclude missing price/rating" behavior, update it to match the new intent and note it in the commit. Expected: all green.
+
+- [ ] **Step 5: Full suite + typecheck + commit**
+
+```bash
+git add utils/filterBusinesses.ts utils/__tests__/filterBusinesses.test.ts
+git commit -m "fix(filter): don't exclude businesses for missing price/rating (multi-provider)"
+```
+
+---
+
+### Task 5: Route `useResults` through the registry
+
+**Files:**
+- Modify: `hooks/useResults.ts`
+- Create: `providers/index.ts` (exports `DEFAULT_PROVIDERS`)
+- Test: `__tests__/hooks/useResults.providers.test.tsx` (new)
+
+Replace the inline `yelp.get('/businesses/search')` block in BOTH `searchApi` and `searchApiWithResolver` with a registry call. Keep the existing closed/non-food post-filter (`is_closed`, `hasBlockedCategory`) — now applied uniformly to whatever provider returned. Cache only when the used provider is `cacheable`.
+
+- [ ] **Step 1: Add the default provider list**
+
+Create `providers/index.ts`:
+```ts
+import { RestaurantProvider } from './types';
+import { yelpProvider } from './yelpProvider';
+import { osmProvider } from './osmProvider';
+
+// Priority order: Yelp primary, OpenStreetMap fallback.
+export const DEFAULT_PROVIDERS: RestaurantProvider[] = [yelpProvider, osmProvider];
+
+export { searchRestaurants } from './registry';
+export * from './types';
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `__tests__/hooks/useResults.providers.test.tsx`. Mock the registry so we assert `useResults` routes through it and applies the closed/non-food post-filter. Render a harness that calls `searchApi` and inspect the returned businesses.
+```tsx
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import useResults from '../../hooks/useResults';
+
+jest.mock('../../providers', () => ({
+  DEFAULT_PROVIDERS: [{ id: 'yelp' }, { id: 'osm' }],
+  searchRestaurants: jest.fn(),
+}));
+import { searchRestaurants } from '../../providers';
+const mockSearch = searchRestaurants as jest.Mock;
+
+// Neutralize persistence so no real cache/AsyncStorage runs.
+jest.mock('../../hooks/useResultsPersistence', () => ({
+  __esModule: true,
+  default: () => ({
+    getCachedResults: jest.fn().mockResolvedValue(null),
+    cacheResults: jest.fn().mockResolvedValue(undefined),
+    generateCacheKey: jest.fn().mockReturnValue('k'),
+    getCachedResultsByKey: jest.fn().mockResolvedValue(null),
+    cacheResultsByKey: jest.fn().mockResolvedValue(undefined),
+    clearOldCache: jest.fn(),
+  }),
+}));
+
+let api: ReturnType<typeof useResults>;
+function Harness() { api = useResults(); return null; }
+
+const food = { id: 'osm:node/1', name: 'Cafe', categories: [{ alias: 'coffee', title: 'coffee' }], is_closed: false };
+const closed = { id: 'y2', name: 'Closed', categories: [], is_closed: true };
+
+describe('useResults routes through the provider registry', () => {
+  beforeEach(() => mockSearch.mockReset());
+
+  it('calls the registry and drops closed businesses', async () => {
+    mockSearch.mockResolvedValue({ results: [food, closed], usedProvider: 'osm', errors: {} });
+    render(<Harness />);
+    const businesses = await api[2]('coffee', 'Columbus', { latitude: 40, longitude: -83 } as any, 1600);
+    expect(mockSearch).toHaveBeenCalled();
+    expect(businesses.map((b: any) => b.id)).toEqual(['osm:node/1']); // closed dropped
+  });
+});
+```
+NOTE: adapt indices (`api[2]` = `searchApi` per the `return [...] as const` order) and the harness to how the existing `useResults` tests render/consume the hook — check `__tests__/hooks/` for the established pattern and match it (some suites call the returned functions directly, some wrap in a component).
+
+- [ ] **Step 3: Run to verify it fails**
+
+Run: `yarn jest __tests__/hooks/useResults.providers.test.tsx` → FAIL (still calls `yelp.get`, not the registry).
+
+- [ ] **Step 4: Refactor `useResults`**
+
+In `hooks/useResults.ts`:
+1. Replace the `import yelp from "../api/yelp";` usage for search with:
+```ts
+import { DEFAULT_PROVIDERS, searchRestaurants } from '../providers';
+```
+2. Extract the shared post-processing into a helper (top of the hook module or inside the component):
+```ts
+function keepFoodAndOpen(businesses: BusinessProps[]): BusinessProps[] {
+  return businesses.filter(business => {
+    if (business.is_closed) return false;
+    const categoryAliases = business.categories?.map(c => c.alias) || [];
+    if (hasBlockedCategory(categoryAliases)) return false;
+    return true;
+  });
+}
+```
+3. In `searchApi`, replace the block from `const response: AxiosResponse = await yelp.get(...)` through the `if (response.data && response.data.businesses) { … } else { … }` with:
+```ts
+        const outcome = await searchRestaurants(DEFAULT_PROVIDERS, {
+          term: searchTerm,
+          coordinates: coords?.latitude && coords?.longitude ? coords : null,
+          locationLabel: location,
+          radiusMeters: radius,
+        });
+        const filteredBusinesses = keepFoodAndOpen(outcome.results);
+        const finalResults: ResultsProps = { id: uuid(), businesses: filteredBusinesses };
+
+        const usedCacheable = DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
+        if (usedCacheable) {
+          await resultsPersistence.cacheResults(location, searchTerm, filteredBusinesses, coords, radius);
+        }
+        setResults(finalResults);
+        return filteredBusinesses;
+```
+4. In `searchApiWithResolver`, replace the equivalent `yelp.get(...)` block with:
+```ts
+        const outcome = await searchRestaurants(DEFAULT_PROVIDERS, {
+          term: searchTerm,
+          coordinates: resolvedLocation.coords?.latitude && resolvedLocation.coords?.longitude ? resolvedLocation.coords : null,
+          locationLabel: resolvedLocation.label,
+          radiusMeters: radius,
+        });
+        const filteredBusinesses = keepFoodAndOpen(outcome.results);
+        const finalResults: ResultsProps = { id: uuid(), businesses: filteredBusinesses };
+
+        const usedCacheable = DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
+        if (usedCacheable) {
+          await resultsPersistence.cacheResultsByKey(cacheKey, filteredBusinesses);
+        }
+        setResults(finalResults);
+        return filteredBusinesses;
+```
+5. Remove the now-unused `AxiosResponse`/`logNetwork`/`yelp` imports if nothing else uses them (grep the file; leave anything still referenced). Keep the try/catch error handling and the cache-read blocks unchanged.
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `yarn jest __tests__/hooks/useResults.providers.test.tsx` and the existing useResults suites → PASS. Fix any existing useResults test that mocked `api/yelp` directly (it now goes through the registry — either mock `../../providers` there too, or leave Yelp mocked since the real registry calls the real yelpProvider which calls the mocked `api/yelp`; prefer the latter for existing tests so they exercise the real path).
+
+- [ ] **Step 6: Full suite + typecheck + commit**
+
+Run `yarn jest` (all green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (≤158).
+```bash
+git add hooks/useResults.ts providers/index.ts __tests__/hooks/useResults.providers.test.tsx
+git commit -m "feat(providers): route useResults through the provider registry with cache-policy gate"
+```
+
+---
+
+### Task 6: OpenStreetMap attribution in the UI
+
+**Files:**
+- Create: `components/shared/ProviderAttribution.tsx`
+- Modify: the results list header (Search results) — `screens/SearchScreen.tsx` (confirm the header component it renders)
+- Test: `components/shared/__tests__/ProviderAttribution.test.tsx`
+
+ODbL requires "© OpenStreetMap contributors" attribution when OSM data is displayed. Show it whenever any visible business came from OSM (id starts with `osm:`). Yelp attribution behavior is unchanged.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `components/shared/__tests__/ProviderAttribution.test.tsx`:
+```tsx
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ProviderAttribution } from '../ProviderAttribution';
+
+describe('ProviderAttribution', () => {
+  it('shows OSM attribution when an osm business is present', () => {
+    const { getByText } = render(
+      <ProviderAttribution businesses={[{ id: 'osm:node/1' } as any, { id: 'y1' } as any]} />
+    );
+    expect(getByText(/OpenStreetMap/)).toBeTruthy();
+  });
+  it('renders nothing when no osm businesses are present', () => {
+    const { queryByText } = render(
+      <ProviderAttribution businesses={[{ id: 'y1' } as any]} />
+    );
+    expect(queryByText(/OpenStreetMap/)).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `yarn jest components/shared/__tests__/ProviderAttribution.test.tsx` → FAIL.
+
+- [ ] **Step 3: Implement**
+
+Create `components/shared/ProviderAttribution.tsx`:
+```tsx
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
+import { BusinessProps } from '../../hooks/useResults';
+import { supperClub } from '../../theme/supperClub';
+
+export const ProviderAttribution: React.FC<{ businesses: BusinessProps[] }> = ({ businesses }) => {
+  const hasOsm = businesses.some(b => typeof b.id === 'string' && b.id.startsWith('osm:'));
+  if (!hasOsm) return null;
+  return <Text style={styles.text}>Data © OpenStreetMap contributors</Text>;
+};
+
+const styles = StyleSheet.create({
+  text: { fontSize: 11, color: supperClub.textMuted, textAlign: 'center', paddingVertical: 8 },
+});
+
+export default ProviderAttribution;
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `yarn jest components/shared/__tests__/ProviderAttribution.test.tsx` → PASS.
+
+- [ ] **Step 5: Render it in the Search results**
+
+In `screens/SearchScreen.tsx`, render `<ProviderAttribution businesses={state.results} />` in the results list footer (e.g. `ListFooterComponent`, or after the list). Import it. Keep it out of the empty state. Verify by reading the current results-list JSX and placing it where a footer naturally fits.
+
+- [ ] **Step 6: Full suite + typecheck + commit**
+
+Run `yarn jest` (green) and `npx tsc --noEmit 2>&1 | grep -c "error TS"` (≤158).
+```bash
+git add components/shared/ProviderAttribution.tsx components/shared/__tests__/ProviderAttribution.test.tsx screens/SearchScreen.tsx
+git commit -m "feat(providers): show OpenStreetMap attribution when OSM results are displayed"
+```
+
+---
+
+## Self-review notes (author checklist — applied)
+
+- **Spec coverage:** provider interface + `cachePolicy` (T1), registry fallback-only (T1), Yelp adapter (T2), OSM adapter + cuisine→alias normalization + reuse-coords/skip-Nominatim (T3), graceful missing-field filtering (T4), `useResults` integration + cache-policy gate (T5), OSM attribution (T6). Category-alias tie to Dealbreakers preserved (OSM aliases flow into the same `categories[].alias` the reducer filters on).
+- **Decisions honored:** fallback-only (T1/T5), OSM missing rating/price shown gracefully (T3 sets `0`/`''`; T4 stops filters excluding them), abstraction-layer-only scope (no bulk base, no premium providers — out of scope in spec).
+- **No type churn:** `BusinessProps` reused as the normalized type; OSM fills all required fields with sensible empties — keeps tsc at the 158 baseline (verified each task).
+- **Placeholders:** none — every step has literal test + impl code. Two steps say "match the existing test/JSX pattern" (useResults harness in T5, results footer in T6) because those depend on current file structure the implementer must read; the required behavior and code are fully specified.
+- **Type consistency:** `ProviderSearchParams` (`coordinates | null`, `locationLabel?`), `RestaurantProvider.search → BusinessProps[]`, `SearchOutcome { results, usedProvider, errors }`, `id` namespaced `osm:<type>/<id>` — used consistently T1→T6.
+
+## Post-implementation
+
+- Run full suite + `tsc`, then ship via branch → PR → `/codex review` gate → squash-merge (repo CLAUDE.md). Pure JS/TS — OTA-deliverable.
+- Follow-ups (documented out-of-scope): confirm Yelp's current free-tier; consider a real `opening_hours` parser so OSM places aren't dropped by the "open now" filter; later, the hybrid static base and premium detail providers using the `cachePolicy: 'no-store'` hook.

--- a/docs/superpowers/specs/2026-07-30-provider-adapter-layer-design.md
+++ b/docs/superpowers/specs/2026-07-30-provider-adapter-layer-design.md
@@ -1,0 +1,290 @@
+# Restaurant Provider Adapter Layer — design
+
+**Date:** 2026-07-30
+**Status:** Design approved, pending spec review
+
+## Goal
+
+Stop being beholden to a single restaurant data source. Introduce a thin
+**provider-adapter layer** so Rouxlette can search across multiple restaurant/POI
+data sources behind one normalized interface, starting with the existing **Yelp**
+client plus a free **OpenStreetMap** fallback. Keep it cheap (this is a
+non-commercial project), keep callers (the reducer, Dealbreakers, UI) unchanged,
+and make adding future providers a drop-in.
+
+Scope for this spec is the **abstraction layer only**. The hybrid bulk-data base
+and premium detail providers are documented as future work, not built here.
+
+## Background: why now, and what the research said
+
+A 2026 pricing/terms review of the major sources produced one decisive finding:
+**no free source carries hours + rating + price together.**
+
+- **Free bulk datasets** — Foursquare OS Places (Apache-2.0, ~109M POIs) and
+  Overture Maps (permissive, ~2,300-term taxonomy) — have excellent category data
+  but **no hours, rating, or price**.
+- **OpenStreetMap** (Overpass API, free, no key) has `cuisine=*` and
+  `opening_hours=*` but **no crowd rating or price level**. Nominatim geocoding is
+  capped at ~1 req/s.
+- **Google Places (New)** has everything, but rating/price/hours push every search
+  to the Enterprise SKU (~$35 / 1,000 calls), it **requires a billing card**, and
+  its ToS **prohibits caching Places results** — which conflicts with Rouxlette's
+  existing AsyncStorage cache.
+- **Foursquare Places (live)** returns the needed fields only on Premium
+  (~$18.75 / 1,000 from day one; 500 free Pro calls/mo don't cover Premium fields).
+- **Apple Maps Server API** returns no rating/price/hours (disqualified on data),
+  and needs the paid Apple Developer membership.
+- **TripAdvisor** has no non-commercial license tier and is being sunset for a new
+  platform in 2026 (avoid).
+- **Yelp** (incumbent) provides categories + rating + price + hours in one call, but
+  tightened its Fusion free tier in 2025. (Yelp's *current* exact free-tier limits
+  were not confirmed in this pass — see Open Questions.)
+
+Implication for architecture: the cheapest robust path over time is a **hybrid**
+(free bulk data for static/category fields, one live API called sparingly for
+dynamic fields). We are **not** building the hybrid now, but the interface is
+designed so it can slot in without breaking callers. For today, Yelp remains the
+rich primary and OSM is a genuinely-free fallback.
+
+## Decisions (locked)
+
+1. **Scope:** abstraction layer only. Hybrid static base and premium providers are
+   future adapters, documented not built.
+2. **Providers implemented now:** `yelp` (wrap the existing client) and `osm`
+   (new, OpenStreetMap via Overpass).
+3. **Combination mode:** **fallback only** — Yelp is primary; OSM is queried only
+   when Yelp errors or returns empty. No cross-provider dedupe/merge in this cut.
+4. **Missing fields (OSM has no rating/price):** show gracefully. OSM places render
+   as "unrated" / price-unknown; the price and rating filters **do not exclude a
+   business merely for lacking that field**.
+
+## Architecture
+
+### Normalized business model
+
+One shape every provider maps into. Provider-specific gaps are explicitly
+**nullable** so the UI can distinguish "unknown" from a real value.
+
+```ts
+// types/providers.ts
+export type ProviderId = 'yelp' | 'osm';
+
+export interface NormalizedBusiness {
+  providerId: ProviderId;
+  providerBusinessId: string;          // id within that provider
+  id: string;                          // stable app id: `${providerId}:${providerBusinessId}`
+  name: string;
+  coordinates: { latitude: number; longitude: number };
+  address?: string;
+  categoryAliases: string[];           // CANONICAL aliases (see Category normalization)
+  rating: number | null;               // null when the provider doesn't supply it (OSM)
+  reviewCount: number | null;
+  priceLevel: 1 | 2 | 3 | 4 | null;    // null when unknown (OSM)
+  hours: OpeningHours | null;          // structured; null when unknown
+  isOpenNow: boolean | null;           // null when unknowable from the source
+  phone?: string;
+  imageUrl?: string;
+  raw?: unknown;                       // original payload, dev/debug only
+}
+
+export interface OpeningHours {
+  // Minimal, provider-agnostic. Enough to answer "open now" and render a summary.
+  // Yelp maps from its hours[].open[]; OSM parses opening_hours=*.
+  raw?: string;                        // e.g. OSM opening_hours string
+  periods?: Array<{ day: number; start: string; end: string }>;
+}
+```
+
+Notes:
+- `id` is namespaced by provider so results from different sources never collide,
+  and so `state.blocked` / favorites keep working across providers (they store `id`).
+- The existing `BusinessProps` type stays the app-facing shape the UI already
+  consumes; adapters produce `NormalizedBusiness` and a single mapper converts to
+  `BusinessProps`. (If `BusinessProps` already matches closely, `NormalizedBusiness`
+  can BE the app type; the implementation plan decides whether to unify or bridge —
+  the spec's requirement is only that `categoryAliases`, nullable `rating`, and
+  nullable `priceLevel` reach the UI intact.)
+
+### Provider interface
+
+```ts
+// providers/types.ts
+export interface RestaurantProvider {
+  id: ProviderId;
+  /** Cache policy for results from this provider. */
+  cachePolicy: 'cacheable' | 'no-store';
+  search(params: {
+    term: string;
+    coordinates: { latitude: number; longitude: number };
+    radiusMeters: number;
+    signal?: AbortSignal;
+  }): Promise<NormalizedBusiness[]>;
+}
+```
+
+`cachePolicy` is forward-looking: `yelp` and `osm` are `'cacheable'`. When a future
+Google adapter is added it declares `'no-store'`, and the cache layer skips storing
+its results — encoding the ToS constraint in one place instead of scattering it.
+
+### Provider registry + fallback
+
+```ts
+// providers/index.ts
+// Ordered by priority. First is primary; the rest are fallbacks in order.
+export const PROVIDER_ORDER: ProviderId[] = ['yelp', 'osm'];
+
+export async function searchRestaurants(params): Promise<{
+  results: NormalizedBusiness[];
+  usedProvider: ProviderId | null;
+  errors: Partial<Record<ProviderId, string>>;
+}> {
+  // Fallback-only: try providers in order; return the first that yields a
+  // non-empty result. Record errors per provider for debugging/telemetry.
+  // If a provider throws, log and continue to the next.
+  // If all return empty, return { results: [], usedProvider: <last tried>, errors }.
+}
+```
+
+Fallback triggers: the primary **throws** (network/HTTP/parse error) OR returns an
+**empty array**. On either, try the next provider in `PROVIDER_ORDER`. Stop at the
+first non-empty result. This is deterministic and adds no dedupe complexity.
+
+### Category normalization (keeps Dealbreakers provider-agnostic)
+
+Filtering (including Dealbreakers) runs on `categoryAliases`. Every provider maps
+its native categories into **one canonical alias space**. Because
+`constants/foodCategories.ts` (`COMMON_CUISINES`, `FOOD_CATEGORIES`) and the
+existing filters already use Yelp-style aliases, **canonical = the current Yelp
+alias space** (YAGNI; can be abstracted to a neutral space later).
+
+- **Yelp adapter:** already uses these aliases — passthrough.
+- **OSM adapter:** carries a small `cuisine=* → canonical alias` map. OSM
+  `cuisine` values are semicolon-delimited (e.g. `italian;pizza`) and use their own
+  vocabulary; the map normalizes the common ones (e.g. `indian → indpak`,
+  `sushi → sushi`, `pizza → pizza`, `burger → burgers`, `mexican → mexican`,
+  `chinese → chinese`, `thai → thai`, `seafood → seafood`, `vegan → vegan`). Unknown
+  cuisine values pass through as-is (lowercased) so they still display, they just
+  won't match a curated dealbreaker chip. The map lives next to `COMMON_CUISINES`
+  so the two stay aligned.
+
+This is the load-bearing tie to the shipped Dealbreakers feature: the reducer's
+`computeVisibleResults` and the "Never show me" chips keep working unchanged,
+whatever source produced the business.
+
+### Caching
+
+Rouxlette already caches search results in AsyncStorage keyed by location+term.
+Extend the cache key to include `usedProvider`, and **only store results when the
+producing provider's `cachePolicy === 'cacheable'`**. Yelp and OSM are both
+cacheable, so behavior is unchanged today; the gate exists so a future `no-store`
+provider can't be cached by accident.
+
+## OpenStreetMap (`osm`) adapter specifics
+
+- **Endpoint:** Overpass API. Query `node/way/relation["amenity"="restaurant"]`
+  within `(around:<radiusMeters>,<lat>,<lon>)`, requesting tags including `name`,
+  `cuisine`, `opening_hours`, `addr:*`, `phone`. Term filtering: Overpass has weak
+  free-text search, so match `term` against `name`/`cuisine` client-side after the
+  spatial query (the spatial query is the cheap part).
+- **Geocoding:** reuse the app's already-resolved coordinates. **Do not call
+  Nominatim** (1 req/s cap, prohibits systematic use). OSM search is coordinates-in,
+  so this is fine.
+- **Rate/fair-use:** send a descriptive `User-Agent`/`Referer` identifying the app
+  (Overpass requires identification). Keep call volume low (fallback-only already
+  does this). Pick a public Overpass endpoint; make it configurable so it can be
+  swapped or self-hosted later.
+- **Field mapping:** `name`→name; lat/lon→coordinates; `cuisine`→`categoryAliases`
+  (via the map above); `opening_hours`→`hours.raw` + parsed `isOpenNow` (parse the
+  common subset; when unparseable, `hours.raw` set and `isOpenNow: null`);
+  `rating: null`, `reviewCount: null`, `priceLevel: null`; `addr:*`→address.
+- **id:** `osm:<type>/<osmId>` (e.g. `osm:node/123`).
+
+## Yelp (`yelp`) adapter
+
+Wrap the existing `api/yelp.ts` behind `RestaurantProvider`. It already returns
+categories/rating/price/hours; the adapter maps its response to
+`NormalizedBusiness` (aliases passthrough, `priceLevel` from `$`-string length,
+`isOpenNow` from `hours[].is_open_now` when present). `cachePolicy: 'cacheable'`.
+No behavior change to Yelp calls themselves.
+
+## Integration points
+
+- **`hooks/useResults.ts`** calls `searchRestaurants(...)` from the registry instead
+  of Yelp directly, then maps `NormalizedBusiness[]` to the app's `BusinessProps[]`
+  for dispatch. Caching logic moves behind the `cachePolicy` gate.
+- **Reducer / Dealbreakers / filters:** unchanged — they consume normalized
+  businesses and `categoryAliases`.
+- **UI graceful degradation (decision #4):**
+  - Rating component renders a neutral "unrated" state when `rating === null`
+    (not 0 stars, which would read as "bad").
+  - Price display shows nothing / "price unknown" when `priceLevel === null`.
+  - **Price and rating filters treat `null` as "not excluded"** — a business is
+    dropped by a price/rating filter only when it *has* a value that fails the
+    filter, never for lacking the field. (This is a small, explicit change to
+    `utils/filterBusinesses.ts`.)
+- **Provider attribution:** when OSM results are shown, display the required
+  "© OpenStreetMap contributors" attribution (ODbL). A small footer/label on the
+  results list satisfies this. Yelp attribution rules already apply to Yelp results.
+
+## Data flow
+
+1. Search input → `useResults` → `searchRestaurants({term, coords, radius})`.
+2. Registry tries `yelp`; on throw or empty, tries `osm`.
+3. First non-empty provider's `NormalizedBusiness[]` returns (with `usedProvider`).
+4. `useResults` maps to `BusinessProps[]`, dispatches `setResults` (reducer applies
+   Dealbreakers/filters/blocked as today).
+5. Results cached iff `cachePolicy === 'cacheable'`, key includes `usedProvider`.
+
+## Error handling
+
+- A provider that throws is logged (`logSafe`) with `{ providerId, message }`,
+  recorded in the returned `errors` map, and does not abort the search — the next
+  provider is tried.
+- If **all** providers fail or return empty, the registry returns an empty result
+  set; the existing empty-state UI handles it (including the Dealbreakers
+  "all avoided" state shipped earlier).
+- Aborts (`AbortSignal`) propagate to the active provider call.
+
+## Testing
+
+- **Registry (fallback logic):** Yelp non-empty → returns Yelp, OSM never called;
+  Yelp throws → OSM tried; Yelp empty → OSM tried; both empty → empty result +
+  errors recorded; abort propagates.
+- **OSM adapter:** Overpass response fixture → correct `NormalizedBusiness` mapping
+  (name/coords/address/phone), `cuisine` → canonical aliases via the map (incl. a
+  multi-value `a;b` case and an unknown value passthrough), `opening_hours` → `hours`
+  + `isOpenNow` for a parseable case and `null` for an unparseable one, and
+  `rating/reviewCount/priceLevel` all `null`. `cachePolicy === 'cacheable'`.
+- **Yelp adapter:** existing Yelp response fixture → `NormalizedBusiness` mapping,
+  `priceLevel` from `$` length, aliases passthrough, `isOpenNow` mapping.
+- **Cache gate:** `no-store` provider results are not persisted; `cacheable` are.
+- **Filter degradation:** a business with `priceLevel: null` / `rating: null` is
+  NOT excluded by an active price/rating filter; one with a failing value IS.
+- **Category tie-in:** an OSM business whose cuisine maps to a dealbreakered alias
+  is excluded by `computeVisibleResults` exactly like a Yelp one (integration-level
+  assertion that normalization feeds the existing filter).
+
+## Out of scope (explicit, documented as future)
+
+- **Hybrid static base** — ingesting Foursquare OS Places / Overture as a cacheable
+  category/location index with live calls only for dynamic fields. This is the
+  cheapest-at-scale path; deferred until real limits are felt.
+- **Premium detail providers** — Google Places (New) and Foursquare Premium
+  adapters, including Google's no-caching ToS handling (the `cachePolicy: 'no-store'`
+  hook already anticipates it).
+- **Cross-provider dedupe/merge** — this cut is fallback-only; merging both sources
+  by name+geo is a later enhancement.
+- **Per-tap details fetch** — fetching dynamic fields lazily when a user opens a
+  result (the cost-minimizing pattern for paid providers).
+- **Neutral canonical taxonomy** — abstracting the canonical alias space away from
+  Yelp's vocabulary; only worth it once a non-Yelp primary exists.
+
+## Open questions / to verify before/along implementation
+
+- **Yelp current free-tier limits** (2025 tightening) — confirm what the project's
+  key actually allows, since it affects how hard OSM fallback gets exercised.
+- **Overpass endpoint choice** — pick a public instance and confirm its fair-use
+  posture; make it configurable for later self-hosting.
+- **`BusinessProps` vs `NormalizedBusiness`** — the implementation plan decides
+  whether to unify the types or bridge with a mapper; spec only requires the three
+  fields (aliases, nullable rating, nullable price) survive to the UI.

--- a/hooks/useBusinessDetails.ts
+++ b/hooks/useBusinessDetails.ts
@@ -6,6 +6,17 @@ import { logSafe } from '../utils/log';
 // In-memory cache for business details during the app session
 const detailsCache = new Map<string, any>();
 
+/**
+ * Yelp detail enrichment only knows Yelp entities and carries the Yelp API key.
+ * Provider-adapter businesses use a `provider:` prefix in their id (e.g.
+ * `osm:node/123`). Sending those to the Yelp detail endpoint always 404s while
+ * misrouting a key-bearing request and burning Yelp rate limit, so we skip
+ * enrichment for any non-Yelp id. Yelp ids are bare (no provider prefix).
+ */
+function isYelpBusinessId(id: string): boolean {
+  return !id.includes(':');
+}
+
 interface UseBusinessDetailsResult {
   business: BusinessProps;
   loading: boolean;
@@ -62,6 +73,17 @@ export function useBusinessDetails(basicBusiness: BusinessProps, autoFetch = fal
     // Skip if already cached
     if (detailsCache.has(basicBusiness.id)) {
       logSafe('[useBusinessDetails] Already have cached details');
+      return;
+    }
+
+    // Skip Yelp detail enrichment for non-Yelp providers (e.g. `osm:` ids).
+    // Yelp has no data for them; keep the basic search data as-is with no
+    // network call. This is a deliberate skip, not a failure — leave loading
+    // false and surface no error.
+    if (!isYelpBusinessId(basicBusiness.id)) {
+      logSafe('[useBusinessDetails] Skipping Yelp enrichment for non-Yelp business', {
+        id: basicBusiness.id,
+      });
       return;
     }
 

--- a/hooks/useResults.ts
+++ b/hooks/useResults.ts
@@ -154,6 +154,15 @@ export default function useResults() {
 				radiusMeters: radius,
 			});
 
+			// Total outage: every provider threw and nothing came back. Surface it
+			// as an error (the catch below sets the network message and rethrows so
+			// the committed search identity is cleared, #58) rather than silently
+			// showing an empty "no results" state. A provider that ran and returned
+			// empty (no errors entry) is a valid empty search and must NOT throw.
+			if (outcome.results.length === 0 && DEFAULT_PROVIDERS.every(p => outcome.errors[p.id])) {
+				throw new Error('All restaurant providers failed');
+			}
+
 			// Apply the closed/non-food post-filter uniformly to whatever the
 			// used provider returned.
 			const filteredBusinesses = keepFoodAndOpen(outcome.results);
@@ -266,6 +275,15 @@ export default function useResults() {
 				locationLabel: resolvedLocation.label,
 				radiusMeters: radius,
 			});
+
+			// Total outage: every provider threw and nothing came back. Surface it
+			// as an error (the catch below sets the network message and rethrows so
+			// the committed search identity is cleared, #58) rather than silently
+			// showing an empty "no results" state. A provider that ran and returned
+			// empty (no errors entry) is a valid empty search and must NOT throw.
+			if (outcome.results.length === 0 && DEFAULT_PROVIDERS.every(p => outcome.errors[p.id])) {
+				throw new Error('All restaurant providers failed');
+			}
 
 			// Apply the closed/non-food post-filter uniformly to whatever the used
 			// provider returned.

--- a/hooks/useResults.ts
+++ b/hooks/useResults.ts
@@ -1,13 +1,12 @@
 import "react-native-get-random-values";
 import { useState, useEffect, useCallback } from "react";
-import yelp from "../api/yelp";
-import { AxiosResponse } from "axios";
 import useResultsPersistence from "./useResultsPersistence";
 import { v4 as uuid } from "uuid";
-import { logSafe, logArray, logNetwork } from "../utils/log";
+import { logSafe, logArray } from "../utils/log";
 import { LocationObjectCoords } from "expo-location";
 import { ResolvedLocation } from "./useLocation";
 import { hasBlockedCategory } from "../constants/foodCategories";
+import { DEFAULT_PROVIDERS, searchRestaurants } from "../providers";
 
 export const PRICE_OPTIONS = [`$`, `$$`, `$$$`, `$$$$`];
 
@@ -18,6 +17,21 @@ const DEFAULT_RADIUS_METERS = 1600; // ~1 mile
 
 const clampRadius = (radiusMeters: number): number =>
 	Math.min(YELP_MAX_RADIUS_METERS, Math.max(1, Math.round(radiusMeters)));
+
+/**
+ * Uniform post-filter applied to whatever provider the registry used: drop
+ * permanently-closed businesses and non-food categories (body shops, etc.).
+ * This preserves the behavior the inline Yelp path had before the provider
+ * abstraction, now applied to any provider's results.
+ */
+function keepFoodAndOpen(businesses: BusinessProps[]): BusinessProps[] {
+	return businesses.filter(business => {
+		if (business.is_closed) return false;
+		const categoryAliases = business.categories?.map(c => c.alias) || [];
+		if (hasBlockedCategory(categoryAliases)) return false;
+		return true;
+	});
+}
 
 export interface ResultsProps {
 	id: string;
@@ -119,81 +133,47 @@ export default function useResults() {
 				return businesses;
 			}
 
-			devLog('No cache found, making API request...');
+			devLog('No cache found, routing through provider registry...');
 
-			// Determine search parameters
-			// Include categories to ensure we only get food/restaurant results
-			let searchParams: any = {
-				term: searchTerm,
-				limit: 50,
-				categories: 'restaurants,food,bars,cafes,bakeries,desserts,coffee',
-			};
-
-			if (coords?.latitude && coords?.longitude) {
-				// Use coordinates for more accurate search
-				searchParams.latitude = coords.latitude;
-				searchParams.longitude = coords.longitude;
-				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
-				devLog('Using coordinates for search:', coords);
-			} else if (location.trim() !== '') {
-				// Fallback to location string. Yelp supports `radius` with
-				// `location`, so the slider applies on this path too (#55).
-				searchParams.location = location;
-				searchParams.radius = radius;
-				devLog('Using location string for search:', location);
-			} else {
+			// Guard: without coordinates or a usable location string there is
+			// nothing to search. Preserves the prior invalid-params early return.
+			const hasCoords = !!(coords?.latitude && coords?.longitude);
+			if (!hasCoords && location.trim() === '') {
 				devLog('Invalid search parameters');
 				setResults(INIT_RESULTS);
 				return;
 			}
 
-			// Make the API call
-			const response: AxiosResponse = await yelp.get('/businesses/search', {
-				params: searchParams
+			// Try Yelp, then fall back to OpenStreetMap. clampRadius stays in the
+			// hook: the Yelp adapter forwards radius raw, so we pass the already
+			// clamped value to preserve the Yelp 40km max guard (#55).
+			const outcome = await searchRestaurants(DEFAULT_PROVIDERS, {
+				term: searchTerm,
+				coordinates: hasCoords ? coords : null,
+				locationLabel: location,
+				radiusMeters: radius,
 			});
 
-			logNetwork('GET', '/businesses/search', searchParams, {
-				status: response.status,
-				data: response.data,
-			});
+			// Apply the closed/non-food post-filter uniformly to whatever the
+			// used provider returned.
+			const filteredBusinesses = keepFoodAndOpen(outcome.results);
+			logArray('useResults filtered businesses', filteredBusinesses, 3);
 
-			if (response.data && response.data.businesses) {
-				// Ensure businesses is an array and filter out closed businesses
-				const businessesArray = Array.isArray(response.data.businesses) ? response.data.businesses : [];
+			const finalResults: ResultsProps = {
+				id: uuid(),
+				businesses: filteredBusinesses,
+			};
 
-				// Filter out closed businesses and non-food categories
-				const filteredBusinesses = businessesArray.filter((business: BusinessProps) => {
-					// Exclude permanently closed businesses
-					if (business.is_closed) return false;
-
-					// Exclude non-food businesses (body shops, etc.)
-					const categoryAliases = business.categories?.map(c => c.alias) || [];
-					if (hasBlockedCategory(categoryAliases)) {
-						devLog('Filtered out non-food business:', { name: business.name, categories: categoryAliases });
-						return false;
-					}
-
-					return true;
-				});
-
-				logArray('useResults filtered businesses', filteredBusinesses, 3);
-
-				// Create final results object
-				const finalResults: ResultsProps = {
-					id: uuid(),
-					businesses: filteredBusinesses,
-				};
-
-				// Cache the results (this is debounced and change-detected automatically)
+			// Cache only when the used provider allows it.
+			const usedCacheable =
+				DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
+			if (usedCacheable) {
+				// Debounced and change-detected automatically.
 				await resultsPersistence.cacheResults(location, searchTerm, filteredBusinesses, coords, radius);
-
-				setResults(finalResults);
-				return filteredBusinesses;
-			} else {
-				devLog('No businesses in API response');
-				setResults(INIT_RESULTS);
-				return [];
 			}
+
+			setResults(finalResults);
+			return filteredBusinesses;
 		} catch (err: any) {
 			logSafe(`[useResults] searchApi error`, {
 				message: err?.message,
@@ -268,79 +248,44 @@ export default function useResults() {
 				return businesses;
 			}
 
-			devLog('No cache found, making API request with resolved location...');
+			devLog('No cache found, routing through provider registry...');
 
-			// Build Yelp search parameters - prefer coordinates over location string
-			// Include categories to ensure we only get food/restaurant results
-			const searchParams: any = {
-				term: searchTerm,
-				limit: 50,
-				categories: 'restaurants,food,bars,cafes,bakeries,desserts,coffee',
-			};
-
-			if (resolvedLocation.coords?.latitude && resolvedLocation.coords?.longitude) {
-				// PREFERRED: Use coordinates for most accurate search
-				searchParams.latitude = resolvedLocation.coords.latitude;
-				searchParams.longitude = resolvedLocation.coords.longitude;
-				searchParams.radius = radius; // slider-driven, clamped to Yelp max (#55)
-				devLog('Using coordinates for Yelp search:', resolvedLocation.coords);
-			} else if (resolvedLocation.label) {
-				// FALLBACK: Use canonical location string (e.g., "Powell, OH").
-				// Yelp supports `radius` with `location`, so apply it here too (#55).
-				searchParams.location = resolvedLocation.label;
-				searchParams.radius = radius;
-				devLog('Using canonical location string for Yelp search:', resolvedLocation.label);
-			} else {
+			// Prefer coordinates over the location label; the OSM fallback requires
+			// coordinates. clampRadius stays in the hook (see searchApi note) so the
+			// Yelp adapter receives an already-clamped radius (#55).
+			const hasCoords = !!(resolvedLocation.coords?.latitude && resolvedLocation.coords?.longitude);
+			if (!hasCoords && !resolvedLocation.label) {
 				devLog('No valid search location available');
 				setResults(INIT_RESULTS);
 				return;
 			}
 
-			// Make the Yelp API call
-			const response: AxiosResponse = await yelp.get('/businesses/search', {
-				params: searchParams
+			const outcome = await searchRestaurants(DEFAULT_PROVIDERS, {
+				term: searchTerm,
+				coordinates: hasCoords ? resolvedLocation.coords : null,
+				locationLabel: resolvedLocation.label,
+				radiusMeters: radius,
 			});
 
-			logNetwork('GET', '/businesses/search', searchParams, {
-				status: response.status,
-				data: response.data,
-			});
+			// Apply the closed/non-food post-filter uniformly to whatever the used
+			// provider returned.
+			const filteredBusinesses = keepFoodAndOpen(outcome.results);
+			logArray('Enhanced search filtered businesses', filteredBusinesses, 3);
 
-			if (response.data && response.data.businesses) {
-				// Ensure businesses is an array and filter out closed/non-food businesses
-				const businessesArray = Array.isArray(response.data.businesses) ? response.data.businesses : [];
-				const filteredBusinesses = businessesArray.filter((business: BusinessProps) => {
-					// Exclude permanently closed businesses
-					if (business.is_closed) return false;
+			const finalResults: ResultsProps = {
+				id: uuid(),
+				businesses: filteredBusinesses,
+			};
 
-					// Exclude non-food businesses (body shops, etc.)
-					const categoryAliases = business.categories?.map(c => c.alias) || [];
-					if (hasBlockedCategory(categoryAliases)) {
-						devLog('Filtered out non-food business:', { name: business.name, categories: categoryAliases });
-						return false;
-					}
-
-					return true;
-				});
-
-				logArray('Enhanced search filtered businesses', filteredBusinesses, 3);
-
-				// Create final results object
-				const finalResults: ResultsProps = {
-					id: uuid(),
-					businesses: filteredBusinesses,
-				};
-
-				// Cache the results with the specific cache key
+			// Cache (by the versioned key) only when the used provider allows it.
+			const usedCacheable =
+				DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
+			if (usedCacheable) {
 				await resultsPersistence.cacheResultsByKey(cacheKey, filteredBusinesses);
-
-				setResults(finalResults);
-				return filteredBusinesses;
-			} else {
-				devLog('No businesses in API response');
-				setResults(INIT_RESULTS);
-				return [];
 			}
+
+			setResults(finalResults);
+			return filteredBusinesses;
 		} catch (err: any) {
 			logSafe(`[useResults] searchApiWithResolver error`, {
 				message: err?.message,

--- a/hooks/useResults.ts
+++ b/hooks/useResults.ts
@@ -173,10 +173,15 @@ export default function useResults() {
 				businesses: filteredBusinesses,
 			};
 
-			// Cache only when the used provider allows it.
-			const usedCacheable =
-				DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
-			if (usedCacheable) {
+			// Cache only PRIMARY-provider (Yelp) results, and only when its policy
+			// allows it. Caching a fallback (e.g. OSM) under the plain search key
+			// would short-circuit the registry on the next identical search and
+			// prevent the primary from being retried after it recovers.
+			const primaryId = DEFAULT_PROVIDERS[0]?.id;
+			const used = DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider);
+			const shouldCache =
+				!!used && used.cachePolicy === 'cacheable' && outcome.usedProvider === primaryId;
+			if (shouldCache) {
 				// Debounced and change-detected automatically.
 				await resultsPersistence.cacheResults(location, searchTerm, filteredBusinesses, coords, radius);
 			}
@@ -295,10 +300,15 @@ export default function useResults() {
 				businesses: filteredBusinesses,
 			};
 
-			// Cache (by the versioned key) only when the used provider allows it.
-			const usedCacheable =
-				DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider)?.cachePolicy === 'cacheable';
-			if (usedCacheable) {
+			// Cache (by the versioned key) only PRIMARY-provider (Yelp) results, and
+			// only when its policy allows it. Caching a fallback (e.g. OSM) here
+			// would short-circuit the registry on the next identical search and
+			// prevent the primary from being retried after it recovers.
+			const primaryId = DEFAULT_PROVIDERS[0]?.id;
+			const used = DEFAULT_PROVIDERS.find(p => p.id === outcome.usedProvider);
+			const shouldCache =
+				!!used && used.cachePolicy === 'cacheable' && outcome.usedProvider === primaryId;
+			if (shouldCache) {
 				await resultsPersistence.cacheResultsByKey(cacheKey, filteredBusinesses);
 			}
 

--- a/providers/__tests__/osmProvider.test.ts
+++ b/providers/__tests__/osmProvider.test.ts
@@ -47,9 +47,15 @@ describe('osmProvider', () => {
     expect(out.map(b => b.name)).toEqual(['Pizza Palace']);
   });
 
-  it('returns [] when no coordinates are provided', async () => {
-    const out = await osmProvider.search({ term: 'x', coordinates: null, radiusMeters: 1600 });
-    expect(out).toEqual([]);
+  it('throws when no coordinates are provided', async () => {
+    // Without usable coordinates OSM cannot run. It must THROW (not return [])
+    // so the registry records it in outcome.errors.osm. Otherwise a
+    // location-label-only search where Yelp also throws would look like OSM
+    // "ran and returned empty", masking a real network outage as a valid empty
+    // result set (see #58).
+    await expect(
+      osmProvider.search({ term: 'x', coordinates: null, radiusMeters: 1600 } as any),
+    ).rejects.toThrow();
     expect(mockPost).not.toHaveBeenCalled();
   });
 
@@ -69,6 +75,13 @@ describe('osmProvider', () => {
     ] } });
     const out = await osmProvider.search({ term: '', coordinates: { latitude: 40, longitude: -83 }, radiusMeters: 1600 });
     expect(out).toEqual([]);
+  });
+
+  it('requests a raised result cap so term filtering has candidates to match', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [] } });
+    await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+    const query = mockPost.mock.calls[0][1] as string;
+    expect(query).toContain('out center 200;');
   });
 
   it('is cacheable with id osm', () => {

--- a/providers/__tests__/osmProvider.test.ts
+++ b/providers/__tests__/osmProvider.test.ts
@@ -62,6 +62,15 @@ describe('osmProvider', () => {
     expect(out[0].coordinates).toEqual({ latitude: 40.01, longitude: -83.01 });
   });
 
+  it('drops way elements whose center has non-numeric coords', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'way', id: 7, center: { lat: undefined, lon: undefined }, tags: { name: 'Broken Way', cuisine: 'pizza' } },
+      { type: 'way', id: 8, tags: { name: 'No Center', cuisine: 'pizza' } },
+    ] } });
+    const out = await osmProvider.search({ term: '', coordinates: { latitude: 40, longitude: -83 }, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+  });
+
   it('is cacheable with id osm', () => {
     expect(osmProvider.id).toBe('osm');
     expect(osmProvider.cachePolicy).toBe('cacheable');

--- a/providers/__tests__/osmProvider.test.ts
+++ b/providers/__tests__/osmProvider.test.ts
@@ -1,0 +1,69 @@
+import { osmProvider } from '../osmProvider';
+
+jest.mock('../../api/overpass', () => ({
+  __esModule: true,
+  default: { get: jest.fn(), post: jest.fn() },
+}));
+import overpass from '../../api/overpass';
+const mockPost = (overpass as any).post as jest.Mock;
+
+const coords = { latitude: 40.0, longitude: -83.0 };
+
+describe('osmProvider', () => {
+  beforeEach(() => mockPost.mockReset());
+
+  it('maps Overpass elements to BusinessProps with unknown rating/price', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'node', id: 1, lat: 40.001, lon: -83.001, tags: { name: 'Sushi Place', cuisine: 'sushi', opening_hours: 'Mo-Su 11:00-22:00', 'addr:city': 'Columbus' } },
+      { type: 'node', id: 2, lat: 40.002, lon: -83.002, tags: { name: 'Curry House', cuisine: 'indian;vegetarian' } },
+    ] } });
+
+    const out = await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+
+    expect(out.map(b => b.id)).toEqual(['osm:node/1', 'osm:node/2']);
+    expect(out[0].name).toBe('Sushi Place');
+    expect(out[0].rating).toBe(0);
+    expect(out[0].review_count).toBe(0);
+    expect(out[0].price).toBe('');
+    expect(out[0].is_closed).toBe(false);
+    expect(out[0].categories.map(c => c.alias)).toContain('sushi');
+    // 'indian' maps to canonical 'indpak'; unknown 'vegetarian' passes through
+    expect(out[1].categories.map(c => c.alias)).toEqual(expect.arrayContaining(['indpak', 'vegetarian']));
+    expect(out[0].distance).toBeGreaterThan(0);
+  });
+
+  it('drops elements without a name', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [ { type: 'node', id: 3, lat: 40, lon: -83, tags: { cuisine: 'pizza' } } ] } });
+    const out = await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+  });
+
+  it('filters by term against name/cuisine when a term is given', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'node', id: 1, lat: 40, lon: -83, tags: { name: 'Pizza Palace', cuisine: 'pizza' } },
+      { type: 'node', id: 2, lat: 40, lon: -83, tags: { name: 'Taco Town', cuisine: 'mexican' } },
+    ] } });
+    const out = await osmProvider.search({ term: 'pizza', coordinates: coords, radiusMeters: 1600 });
+    expect(out.map(b => b.name)).toEqual(['Pizza Palace']);
+  });
+
+  it('returns [] when no coordinates are provided', async () => {
+    const out = await osmProvider.search({ term: 'x', coordinates: null, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('maps way elements using center coordinates', async () => {
+    mockPost.mockResolvedValue({ data: { elements: [
+      { type: 'way', id: 9, center: { lat: 40.01, lon: -83.01 }, tags: { name: 'Big Bistro', cuisine: 'french' } },
+    ] } });
+    const out = await osmProvider.search({ term: '', coordinates: coords, radiusMeters: 1600 });
+    expect(out[0].id).toBe('osm:way/9');
+    expect(out[0].coordinates).toEqual({ latitude: 40.01, longitude: -83.01 });
+  });
+
+  it('is cacheable with id osm', () => {
+    expect(osmProvider.id).toBe('osm');
+    expect(osmProvider.cachePolicy).toBe('cacheable');
+  });
+});

--- a/providers/__tests__/registry.test.ts
+++ b/providers/__tests__/registry.test.ts
@@ -1,0 +1,54 @@
+import { searchRestaurants } from '../registry';
+import { RestaurantProvider, ProviderSearchParams } from '../types';
+
+const params: ProviderSearchParams = {
+  term: 'pizza',
+  coordinates: { latitude: 40, longitude: -83 },
+  radiusMeters: 1600,
+};
+const biz = (id: string) => ({ id, name: id, categories: [] } as any);
+
+const provider = (id: any, impl: () => Promise<any[]>): RestaurantProvider =>
+  ({ id, cachePolicy: 'cacheable', search: impl });
+
+describe('searchRestaurants (fallback-only)', () => {
+  it('returns the primary provider results and does not call the fallback', async () => {
+    const osm = jest.fn().mockResolvedValue([biz('o1')]);
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.resolve([biz('y1')])), provider('osm', osm)],
+      params,
+    );
+    expect(out.results.map(b => b.id)).toEqual(['y1']);
+    expect(out.usedProvider).toBe('yelp');
+    expect(osm).not.toHaveBeenCalled();
+  });
+
+  it('falls back when the primary throws', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.reject(new Error('boom'))), provider('osm', () => Promise.resolve([biz('o1')]))],
+      params,
+    );
+    expect(out.results.map(b => b.id)).toEqual(['o1']);
+    expect(out.usedProvider).toBe('osm');
+    expect(out.errors.yelp).toContain('boom');
+  });
+
+  it('falls back when the primary returns empty', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.resolve([])), provider('osm', () => Promise.resolve([biz('o1')]))],
+      params,
+    );
+    expect(out.usedProvider).toBe('osm');
+    expect(out.results.map(b => b.id)).toEqual(['o1']);
+  });
+
+  it('returns empty with errors when all providers fail or are empty', async () => {
+    const out = await searchRestaurants(
+      [provider('yelp', () => Promise.reject(new Error('x'))), provider('osm', () => Promise.resolve([]))],
+      params,
+    );
+    expect(out.results).toEqual([]);
+    expect(out.usedProvider).toBe('osm'); // last attempted
+    expect(out.errors.yelp).toContain('x');
+  });
+});

--- a/providers/__tests__/yelpProvider.test.ts
+++ b/providers/__tests__/yelpProvider.test.ts
@@ -1,0 +1,46 @@
+import { yelpProvider } from '../yelpProvider';
+
+jest.mock('../../api/yelp', () => ({
+  __esModule: true,
+  default: { get: jest.fn() },
+}));
+import yelp from '../../api/yelp';
+const mockGet = (yelp as any).get as jest.Mock;
+
+describe('yelpProvider', () => {
+  beforeEach(() => mockGet.mockReset());
+
+  it('searches by coordinates and returns businesses', async () => {
+    mockGet.mockResolvedValue({ data: { businesses: [{ id: 'y1', name: 'A', categories: [] }] } });
+    const out = await yelpProvider.search({
+      term: 'pizza',
+      coordinates: { latitude: 40, longitude: -83 },
+      radiusMeters: 1600,
+    });
+    expect(out.map(b => b.id)).toEqual(['y1']);
+    const [, opts] = mockGet.mock.calls[0];
+    expect(opts.params.latitude).toBe(40);
+    expect(opts.params.longitude).toBe(-83);
+    expect(opts.params.radius).toBe(1600);
+    expect(opts.params.term).toBe('pizza');
+  });
+
+  it('searches by location label when no coordinates', async () => {
+    mockGet.mockResolvedValue({ data: { businesses: [] } });
+    await yelpProvider.search({ term: 'tacos', coordinates: null, locationLabel: 'Columbus, OH', radiusMeters: 3000 });
+    const [, opts] = mockGet.mock.calls[0];
+    expect(opts.params.location).toBe('Columbus, OH');
+    expect(opts.params.latitude).toBeUndefined();
+  });
+
+  it('returns [] when the response has no businesses array', async () => {
+    mockGet.mockResolvedValue({ data: {} });
+    const out = await yelpProvider.search({ term: 'x', coordinates: { latitude: 1, longitude: 2 }, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+  });
+
+  it('has cachePolicy cacheable and id yelp', () => {
+    expect(yelpProvider.id).toBe('yelp');
+    expect(yelpProvider.cachePolicy).toBe('cacheable');
+  });
+});

--- a/providers/__tests__/yelpProvider.test.ts
+++ b/providers/__tests__/yelpProvider.test.ts
@@ -23,6 +23,8 @@ describe('yelpProvider', () => {
     expect(opts.params.longitude).toBe(-83);
     expect(opts.params.radius).toBe(1600);
     expect(opts.params.term).toBe('pizza');
+    expect(opts.params.limit).toBe(50);
+    expect(opts.params.categories).toBe('restaurants,food,bars,cafes,bakeries,desserts,coffee');
   });
 
   it('searches by location label when no coordinates', async () => {
@@ -37,6 +39,12 @@ describe('yelpProvider', () => {
     mockGet.mockResolvedValue({ data: {} });
     const out = await yelpProvider.search({ term: 'x', coordinates: { latitude: 1, longitude: 2 }, radiusMeters: 1600 });
     expect(out).toEqual([]);
+  });
+
+  it('returns [] without calling the API when neither coordinates nor a location label are given', async () => {
+    const out = await yelpProvider.search({ term: 'x', coordinates: null, radiusMeters: 1600 });
+    expect(out).toEqual([]);
+    expect(mockGet).not.toHaveBeenCalled();
   });
 
   it('has cachePolicy cacheable and id yelp', () => {

--- a/providers/index.ts
+++ b/providers/index.ts
@@ -1,0 +1,9 @@
+import { RestaurantProvider } from './types';
+import { yelpProvider } from './yelpProvider';
+import { osmProvider } from './osmProvider';
+
+// Priority order: Yelp primary, OpenStreetMap fallback.
+export const DEFAULT_PROVIDERS: RestaurantProvider[] = [yelpProvider, osmProvider];
+
+export { searchRestaurants } from './registry';
+export * from './types';

--- a/providers/osmCuisineMap.ts
+++ b/providers/osmCuisineMap.ts
@@ -1,0 +1,27 @@
+// Maps common OSM `cuisine=*` values into the canonical (Yelp-style) alias space
+// used by COMMON_CUISINES and the Dealbreakers filter. Unknown values pass
+// through lowercased so they still display (they just won't match a curated chip).
+const OSM_CUISINE_TO_ALIAS: Record<string, string> = {
+  indian: 'indpak',
+  sushi: 'sushi',
+  japanese: 'japanese',
+  pizza: 'pizza',
+  italian: 'italian',
+  mexican: 'mexican',
+  chinese: 'chinese',
+  thai: 'thai',
+  burger: 'burgers',
+  seafood: 'seafood',
+  vegan: 'vegan',
+  american: 'tradamerican',
+  coffee_shop: 'coffee',
+};
+
+export function mapCuisineToAliases(cuisine: string | undefined): string[] {
+  if (!cuisine) return [];
+  return cuisine
+    .split(';')
+    .map(c => c.trim().toLowerCase())
+    .filter(Boolean)
+    .map(c => OSM_CUISINE_TO_ALIAS[c] ?? c);
+}

--- a/providers/osmCuisineMap.ts
+++ b/providers/osmCuisineMap.ts
@@ -2,6 +2,9 @@
 // used by COMMON_CUISINES and the Dealbreakers filter. Unknown values pass
 // through lowercased so they still display (they just won't match a curated chip).
 const OSM_CUISINE_TO_ALIAS: Record<string, string> = {
+  // The canonical aliases here intentionally track COMMON_CUISINES (which uses
+  // `indpak`), NOT FOOD_CATEGORIES (which uses `indian`) — the Dealbreaker chips
+  // are the filter that matters, so we normalize to their alias space.
   indian: 'indpak',
   sushi: 'sushi',
   japanese: 'japanese',

--- a/providers/osmProvider.ts
+++ b/providers/osmProvider.ts
@@ -1,0 +1,86 @@
+import overpass from '../api/overpass';
+import { BusinessProps, CoordinatesProps } from '../hooks/useResults';
+import { ProviderSearchParams, RestaurantProvider } from './types';
+import { mapCuisineToAliases } from './osmCuisineMap';
+
+function haversineMeters(a: CoordinatesProps, lat: number, lon: number): number {
+  const R = 6371000;
+  const toRad = (d: number) => (d * Math.PI) / 180;
+  const dLat = toRad(lat - a.latitude);
+  const dLon = toRad(lon - a.longitude);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(a.latitude)) * Math.cos(toRad(lat)) * Math.sin(dLon / 2) ** 2;
+  return Math.round(R * 2 * Math.atan2(Math.sqrt(s), Math.sqrt(1 - s)));
+}
+
+function buildQuery(coords: CoordinatesProps, radiusMeters: number): string {
+  const around = `(around:${radiusMeters},${coords.latitude},${coords.longitude})`;
+  return `[out:json][timeout:25];(node["amenity"="restaurant"]${around};way["amenity"="restaurant"]${around};);out center 50;`;
+}
+
+function elementCoords(el: any): { lat: number; lon: number } | null {
+  if (typeof el.lat === 'number' && typeof el.lon === 'number') return { lat: el.lat, lon: el.lon };
+  if (el.center) return { lat: el.center.lat, lon: el.center.lon };
+  return null;
+}
+
+export const osmProvider: RestaurantProvider = {
+  id: 'osm',
+  cachePolicy: 'cacheable',
+  async search({ term, coordinates, radiusMeters, signal }: ProviderSearchParams): Promise<BusinessProps[]> {
+    if (!coordinates?.latitude || !coordinates?.longitude) return [];
+
+    const response = await overpass.post('', buildQuery(coordinates, radiusMeters), { signal });
+    const elements: any[] = Array.isArray(response?.data?.elements) ? response.data.elements : [];
+    const q = term.trim().toLowerCase();
+
+    const businesses: BusinessProps[] = [];
+    for (const el of elements) {
+      const tags = el.tags || {};
+      const name: string = tags.name;
+      if (!name) continue;
+
+      const pos = elementCoords(el);
+      if (!pos) continue;
+
+      const aliases = mapCuisineToAliases(tags.cuisine);
+
+      if (q) {
+        const haystack = `${name} ${tags.cuisine || ''}`.toLowerCase();
+        if (!haystack.includes(q)) continue;
+      }
+
+      businesses.push({
+        id: `osm:${el.type}/${el.id}`,
+        alias: '',
+        name,
+        coordinates: { latitude: pos.lat, longitude: pos.lon },
+        categories: aliases.map(a => ({ alias: a, title: a })),
+        rating: 0,
+        review_count: 0,
+        price: '',
+        hours: undefined,
+        is_closed: false,
+        distance: haversineMeters(coordinates, pos.lat, pos.lon),
+        display_phone: tags.phone || '',
+        phone: tags.phone || '',
+        image_url: '',
+        photos: [],
+        transactions: [],
+        url: '',
+        location: {
+          address1: tags['addr:street'] || '',
+          address2: null,
+          address3: '',
+          city: tags['addr:city'] || '',
+          country: tags['addr:country'] || '',
+          display_address: [tags['addr:street'], tags['addr:city']].filter(Boolean) as string[],
+          state: tags['addr:state'] || '',
+          zip_code: tags['addr:postcode'] || '',
+        },
+      });
+    }
+    return businesses;
+  },
+};

--- a/providers/osmProvider.ts
+++ b/providers/osmProvider.ts
@@ -16,7 +16,12 @@ function haversineMeters(a: CoordinatesProps, lat: number, lon: number): number 
 
 function buildQuery(coords: CoordinatesProps, radiusMeters: number): string {
   const around = `(around:${radiusMeters},${coords.latitude},${coords.longitude})`;
-  return `[out:json][timeout:25];(node["amenity"="restaurant"]${around};way["amenity"="restaurant"]${around};);out center 50;`;
+  // Fetch up to 200 (was 50). The result set is unfiltered by term server-side,
+  // so client-side term filtering runs on whatever comes back; a higher cap
+  // gives that filter more candidates to match against and cuts the miss rate
+  // in dense areas (a term like "pizza" was starved by the old 50 cap). Pushing
+  // the term into the Overpass query itself is a documented follow-up.
+  return `[out:json][timeout:25];(node["amenity"="restaurant"]${around};way["amenity"="restaurant"]${around};);out center 200;`;
 }
 
 function elementCoords(el: any): { lat: number; lon: number } | null {
@@ -34,7 +39,14 @@ export const osmProvider: RestaurantProvider = {
   id: 'osm',
   cachePolicy: 'cacheable',
   async search({ term, coordinates, radiusMeters, signal }: ProviderSearchParams): Promise<BusinessProps[]> {
-    if (!coordinates?.latitude || !coordinates?.longitude) return [];
+    // Without usable coordinates OSM cannot run. THROW rather than returning []
+    // so the registry records this in outcome.errors.osm. If we returned [],
+    // a location-label-only search where Yelp also failed would read as "OSM
+    // ran and found nothing" — a valid empty result — masking a real network
+    // outage instead of surfacing it (#58).
+    if (!coordinates?.latitude || !coordinates?.longitude) {
+      throw new Error('OSM provider requires coordinates');
+    }
 
     const response = await overpass.post('', buildQuery(coordinates, radiusMeters), { signal });
     const elements: any[] = Array.isArray(response?.data?.elements) ? response.data.elements : [];

--- a/providers/osmProvider.ts
+++ b/providers/osmProvider.ts
@@ -21,7 +21,12 @@ function buildQuery(coords: CoordinatesProps, radiusMeters: number): string {
 
 function elementCoords(el: any): { lat: number; lon: number } | null {
   if (typeof el.lat === 'number' && typeof el.lon === 'number') return { lat: el.lat, lon: el.lon };
-  if (el.center) return { lat: el.center.lat, lon: el.center.lon };
+  // Guard the way `center` the same way as the node branch: Overpass can return
+  // a way with a center object that has missing/non-numeric lat/lon (unresolved
+  // geometry). Returning null there drops the element instead of leaking NaN
+  // coordinates (and a NaN distance) into a BusinessProps.
+  if (el.center && typeof el.center.lat === 'number' && typeof el.center.lon === 'number')
+    return { lat: el.center.lat, lon: el.center.lon };
   return null;
 }
 
@@ -47,6 +52,8 @@ export const osmProvider: RestaurantProvider = {
       const aliases = mapCuisineToAliases(tags.cuisine);
 
       if (q) {
+        // Term filter matches the RAW OSM `cuisine` value + name, not the mapped
+        // canonical aliases (e.g. searching "indpak" won't match `cuisine=indian`).
         const haystack = `${name} ${tags.cuisine || ''}`.toLowerCase();
         if (!haystack.includes(q)) continue;
       }

--- a/providers/registry.ts
+++ b/providers/registry.ts
@@ -1,0 +1,29 @@
+import { logSafe } from '../utils/log';
+import { ProviderSearchParams, RestaurantProvider, SearchOutcome } from './types';
+
+/**
+ * Fallback-only search: try providers in order; return the first non-empty
+ * result. A provider that throws is logged and skipped. If every provider is
+ * empty or throws, return an empty result set with the per-provider errors.
+ */
+export async function searchRestaurants(
+  providers: RestaurantProvider[],
+  params: ProviderSearchParams,
+): Promise<SearchOutcome> {
+  const errors: SearchOutcome['errors'] = {};
+  let usedProvider: SearchOutcome['usedProvider'] = null;
+
+  for (const provider of providers) {
+    usedProvider = provider.id;
+    try {
+      const results = await provider.search(params);
+      if (results.length > 0) {
+        return { results, usedProvider, errors };
+      }
+    } catch (err: any) {
+      errors[provider.id] = err?.message ?? String(err);
+      logSafe('[providers] provider search failed', { providerId: provider.id, message: errors[provider.id] });
+    }
+  }
+  return { results: [], usedProvider, errors };
+}

--- a/providers/types.ts
+++ b/providers/types.ts
@@ -1,0 +1,23 @@
+import { BusinessProps, CoordinatesProps } from '../hooks/useResults';
+
+export type ProviderId = 'yelp' | 'osm';
+
+export interface ProviderSearchParams {
+  term: string;
+  coordinates: CoordinatesProps | null; // OSM requires this; Yelp prefers it
+  locationLabel?: string;                // Yelp fallback when no coords
+  radiusMeters: number;
+  signal?: AbortSignal;
+}
+
+export interface RestaurantProvider {
+  id: ProviderId;
+  cachePolicy: 'cacheable' | 'no-store';
+  search(params: ProviderSearchParams): Promise<BusinessProps[]>;
+}
+
+export interface SearchOutcome {
+  results: BusinessProps[];
+  usedProvider: ProviderId | null;
+  errors: Partial<Record<ProviderId, string>>;
+}

--- a/providers/yelpProvider.ts
+++ b/providers/yelpProvider.ts
@@ -1,0 +1,47 @@
+import yelp from '../api/yelp';
+import { BusinessProps } from '../hooks/useResults';
+import { ProviderSearchParams, RestaurantProvider } from './types';
+
+// Mirrors the category filter used by the existing Yelp search in useResults so
+// the provider stays behavior-compatible with today's request.
+const YELP_CATEGORIES = 'restaurants,food,bars,cafes,bakeries,desserts,coffee';
+
+/**
+ * Yelp adapter for the RestaurantProvider interface.
+ *
+ * Wraps the existing `yelp.get('/businesses/search')` call, building the same
+ * params (term, limit, categories, plus coordinates+radius OR location+radius)
+ * and returning the raw `businesses` array. Closed/non-food filtering and
+ * caching intentionally remain in useResults.
+ */
+export const yelpProvider: RestaurantProvider = {
+  id: 'yelp',
+  cachePolicy: 'cacheable',
+  async search({
+    term,
+    coordinates,
+    locationLabel,
+    radiusMeters,
+  }: ProviderSearchParams): Promise<BusinessProps[]> {
+    const params: any = {
+      term,
+      limit: 50,
+      categories: YELP_CATEGORIES,
+    };
+
+    if (coordinates?.latitude && coordinates?.longitude) {
+      params.latitude = coordinates.latitude;
+      params.longitude = coordinates.longitude;
+      params.radius = radiusMeters;
+    } else if (locationLabel && locationLabel.trim() !== '') {
+      params.location = locationLabel;
+      params.radius = radiusMeters;
+    } else {
+      return [];
+    }
+
+    const response = await yelp.get('/businesses/search', { params });
+    const businesses = response?.data?.businesses;
+    return Array.isArray(businesses) ? (businesses as BusinessProps[]) : [];
+  },
+};

--- a/screens/SearchScreen.tsx
+++ b/screens/SearchScreen.tsx
@@ -28,6 +28,7 @@ import {useBlockFavorite} from '../hooks/useBlockFavorite';
 import {useBlocked} from '../hooks/useBlocked';
 import {useDealbreakers} from '../hooks/useDealbreakers';
 import {AvoidingBar} from '../components/AvoidingBar';
+import {ProviderAttribution} from '../components/shared/ProviderAttribution';
 import FiltersSheet from '../components/filter/FiltersSheet';
 import {applyFilters, countActiveFilters} from '../utils/filterBusinesses';
 import {RootTabScreenProps} from '../types';
@@ -514,6 +515,7 @@ export const SearchScreen: React.FC = () => {
                             onFavoriteToggle={() => handleFavoriteToggle(item.id)}
                         />
                     )}
+                    ListFooterComponent={<ProviderAttribution businesses={state.results}/>}
                     contentContainerStyle={styles.listContent}
                     showsVerticalScrollIndicator={false}
                 />

--- a/utils/filterBusinesses.ts
+++ b/utils/filterBusinesses.ts
@@ -31,12 +31,10 @@ export function applyFilters(businesses: BusinessProps[], filters: Filters): Bus
       }
     }
 
-    // Price filter
-    if (filters.priceLevels.length > 0) {
-      if (!business.price) {
-        return false; // Exclude businesses without price information
-      }
-      const businessPriceLevel = business.price.length as 1|2|3|4;
+    // Price filter — only exclude a business that HAS a price not in the
+    // selected levels. Unknown price (e.g. OSM) passes (#providers).
+    if (filters.priceLevels.length > 0 && business.price) {
+      const businessPriceLevel = business.price.length as 1 | 2 | 3 | 4;
       if (!filters.priceLevels.includes(businessPriceLevel)) {
         return false;
       }
@@ -69,11 +67,10 @@ export function applyFilters(businesses: BusinessProps[], filters: Filters): Bus
       return false;
     }
 
-    // Minimum rating filter
-    if (filters.minRating > 0) {
-      if (!business.rating || business.rating < filters.minRating) {
-        return false;
-      }
+    // Minimum rating filter — only exclude a business that HAS a rating below
+    // the threshold. Unknown rating (0 / null, e.g. OSM) passes (#providers).
+    if (filters.minRating > 0 && business.rating && business.rating < filters.minRating) {
+      return false;
     }
 
     return true;


### PR DESCRIPTION
## Summary

Introduces a thin **provider-adapter layer** so restaurant search is no longer beholden to a single source. Search now runs through a `RestaurantProvider` interface with a fallback-only registry: **Yelp** stays the primary, and a free **OpenStreetMap** (Overpass) adapter serves as a fallback when Yelp errors or returns nothing. The reducer, Dealbreakers, and UI contracts are unchanged — adapters produce the existing `BusinessProps` shape.

Scope is the **abstraction layer only**. Building a hybrid bulk-data base and premium detail providers (Google/Foursquare) is documented as future work; the `cachePolicy` hook already anticipates a no-cache provider.

Design: `docs/superpowers/specs/2026-07-30-provider-adapter-layer-design.md`
Plan: `docs/superpowers/plans/2026-07-30-provider-adapter-layer.md`

## Background

A 2026 pricing/terms review of the major sources found that **no free source carries hours + rating + price together**: the free bulk datasets (Foursquare OS, Overture) and OpenStreetMap have great category data but no crowd rating or price. Google Places has everything but needs a billing card, pushes rating/price/hours to its priciest SKU, and prohibits caching. So the pragmatic first step is the abstraction (swap-in providers, Yelp + a free OSM fallback), not a data pipeline.

## What's included

- **`providers/` layer** — `RestaurantProvider` interface (`search()` + `cachePolicy`), fallback-only `searchRestaurants()` registry (`DEFAULT_PROVIDERS = [yelp, osm]`).
- **Yelp adapter** — wraps the existing Yelp request behind the interface with request parity locked by tests (`limit`, `categories`, radius-on-both-paths).
- **OSM adapter** — Overpass query for `amenity=restaurant` around the caller's coordinates (no Nominatim), mapping each element to `BusinessProps`. Unknown fields become `rating: 0` / `price: ''` / `hours: undefined` (which already read as "unknown" in the existing UI). A cuisine→canonical-alias map (`osmCuisineMap.ts`) normalizes OSM `cuisine=*` into the same Yelp-style alias space the Dealbreakers filter uses, so exclusions keep working across providers.
- **Filter fix** — `applyFilters` no longer excludes a business for *lacking* price/rating; it excludes only when a known value fails the filter. Without this, every OSM result would vanish under a price/rating filter. (Applies uniformly to Yelp too — a place with no price/rating is no longer hidden.)
- **`useResults` integration** — both search paths route through the registry, keep `clampRadius` (Yelp 40km guard, #55), apply the closed/non-food post-filter uniformly, and cache only when the used provider is `cacheable`.
- **OSM attribution** — ODbL "© OpenStreetMap contributors" shown in the Search results footer when any visible business is OSM-sourced.

## Notable review fixes

- **Total-outage vs genuine-empty (#58):** the registry swallows a single provider's failure to fall back — but if *every* provider errors, `useResults` now throws so the network-error message shows and the committed search identity clears (preserving #58). A provider that ran and returned empty is a valid empty search and does not throw. Locked by tests on both search paths.
- **OSM detail calls (holistic review):** opening an OSM business no longer fires a Yelp detail request. `useBusinessDetails` skips enrichment for any `provider:`-prefixed id, so we don't send the Yelp key to a bogus URL or burn rate limit on guaranteed 404s.
- **OSM `way` center guard:** malformed Overpass `center` coords are dropped instead of emitting `NaN` distances.

## Testing

TDD throughout. Full suite: **485 passing** (53 suites). TypeScript held at the 158-error baseline. New coverage: registry fallback semantics, Yelp param parity, OSM mapping (node/way, cuisine→alias, unknown passthrough, NaN-center guard, term filter), filter degradation (both directions), `useResults` routing + cache-gate + total-outage on both paths, and OSM-id detail-skip.

## Documented follow-ups (not blocking)

- OSM term matching is substring-only against raw name+cuisine (fallback-only).
- The Overpass `User-Agent` is best-effort on the RN native network layer.
- `COMMON_CUISINES` uses Yelp-correct aliases (`indpak`, etc.) that diverge from the older `FOOD_CATEGORIES` list; the OSM map tracks `COMMON_CUISINES` (the chips that filter). Reconciling the legacy list is separate cleanup.
- Future: hybrid bulk static base + premium detail providers via the `cachePolicy: 'no-store'` hook.
